### PR TITLE
Asset replication

### DIFF
--- a/Source/ChanneldUE/ChanneldUtils.h
+++ b/Source/ChanneldUE/ChanneldUtils.h
@@ -251,17 +251,23 @@ public:
 	static unrealpb::AssetRef GetAssetRef(const UObject* Obj)
 	{
 		unrealpb::AssetRef Ref;
-		Ref.set_objectpath(std::string(TCHAR_TO_UTF8(*Obj->GetPathName())));
+		if (Obj)
+		{
+			Ref.set_objectpath(std::string(TCHAR_TO_UTF8(*Obj->GetPathName())));
+		}
 		return Ref;
 	}
 	
 	static UObject* GetAssetByRef(const unrealpb::AssetRef* Ref)
 	{
-		const FAssetRegistryModule& AssetRegistryModule = FModuleManager::Get().LoadModuleChecked<FAssetRegistryModule>(TEXT("AssetRegistry"));
-		const FAssetData AssetData = AssetRegistryModule.Get().GetAssetByObjectPath(UTF8_TO_TCHAR(Ref->objectpath().c_str()));
-		if (AssetData.IsValid())
+		if (Ref->objectpath().size() > 0)
 		{
-			return AssetData.GetAsset();
+			const FAssetRegistryModule& AssetRegistryModule = FModuleManager::Get().LoadModuleChecked<FAssetRegistryModule>(TEXT("AssetRegistry"));
+			const FAssetData AssetData = AssetRegistryModule.Get().GetAssetByObjectPath(UTF8_TO_TCHAR(Ref->objectpath().c_str()));
+			if (AssetData.IsValid())
+			{
+				return AssetData.GetAsset();
+			}
 		}
 		return nullptr;
 	}

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/AssetPropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/AssetPropertyDecorator.cpp
@@ -1,0 +1,99 @@
+﻿#include "PropertyDecorator/AssetPropertyDecorator.h"
+
+FString FAssetPropertyDecorator::GetCPPType()
+{
+	return TEXT("UObject*");
+}
+
+FString FAssetPropertyDecorator::GetPropertyType()
+{
+	return TEXT("FObjectProperty");
+}
+
+FString FAssetPropertyDecorator::GetProtoFieldType()
+{
+	return FString::Printf(TEXT("%s.%s"), *GetProtoPackageName(), *GetProtoStateMessageType());
+}
+
+FString FAssetPropertyDecorator::GetProtoPackageName()
+{
+	return TEXT("unrealpb");
+}
+
+FString FAssetPropertyDecorator::GetProtoNamespace()
+{
+	return GetProtoPackageName();
+}
+
+FString FAssetPropertyDecorator::GetProtoStateMessageType()
+{
+	return TEXT("AssetRef");
+}
+
+FString FAssetPropertyDecorator::GetCode_ActorPropEqualToProtoState(const FString& FromActor, const FString& FromState)
+{
+	return FString::Printf(
+		TEXT("%s == ChanneldUtils::GetAssetByRef(&%s->%s())"),
+		*GetCode_GetPropertyValueFrom(FromActor),
+		*FromState, *GetProtoFieldName()
+	);
+}
+
+FString FAssetPropertyDecorator::GetCode_ActorPropEqualToProtoState(const FString& FromActor, const FString& FromState, bool ForceFromPointer)
+{
+	return FString::Printf(
+		TEXT("%s == ChanneldUtils::GetAssetByRef(&%s->%s())"),
+		*GetCode_GetPropertyValueFrom(FromActor, ForceFromPointer),
+		*FromState, *GetProtoFieldName()
+	);
+}
+
+FString FAssetPropertyDecorator::GetCode_GetProtoFieldValueFrom(const FString& StateName)
+{
+	return FString::Printf(
+		TEXT("ChanneldUtils::GetAssetByRef(&%s->%s())"),
+		*StateName, *GetProtoFieldName()
+	);
+}
+
+FString FAssetPropertyDecorator::GetCode_SetProtoFieldValueTo(const FString& StateName, const FString& GetValueCode)
+{
+	return FString::Printf(TEXT("%s->mutable_%s()->CopyFrom(*ChanneldUtils::GetAssetByRef(%s))"), *StateName, *GetProtoFieldName(), *GetValueCode);
+}
+
+FString FAssetPropertyDecorator::GetCode_SetPropertyValueTo(const FString& TargetInstance, const FString& NewStateName, const FString& AfterSetValueCode)
+{
+	return FString::Printf(
+		TEXT("%s = ChanneldUtils::GetAssetByRef(&%s->%s());\n  bStateChanged = true;\n%s"),
+		*GetCode_GetPropertyValueFrom(TargetInstance),
+		*NewStateName, *GetProtoFieldName(),
+		*AfterSetValueCode
+	);
+}
+
+FString FAssetPropertyDecorator::GetCode_SetDeltaStateArrayInner(const FString& PropertyPointer, const FString& FullStateName, const FString& DeltaStateName, bool ConditionFullStateIsNull)
+{
+	FStringFormatNamedArguments FormatArgs;
+	FormatArgs.Add(TEXT("Declare_PropertyPtr"), PropertyPointer);
+	FormatArgs.Add(TEXT("Declare_DeltaStateName"), DeltaStateName);
+	FormatArgs.Add(TEXT("Declare_FullStateName"), FullStateName);
+	FormatArgs.Add(TEXT("Definition_ProtoName"), GetProtoFieldName());
+	return FString::Format(UAssetPropDeco_SetDeltaStateArrayInnerTemp, FormatArgs);
+}
+
+FString FAssetPropertyDecorator::GetCode_SetPropertyValueArrayInner(const FString& PropertyPointer, const FString& NewStateName)
+{
+	FStringFormatNamedArguments FormatArgs;
+	FormatArgs.Add(TEXT("Declare_PropertyPtr"), PropertyPointer);
+	return FString::Format(UAssetPropDeco_OnChangeStateArrayInnerTemp, FormatArgs);
+}
+
+TArray<FString> FAssetPropertyDecorator::GetAdditionalIncludes()
+{
+	return TArray<FString>{TEXT("ChanneldUtils.h")};
+}
+
+FString FAssetPropertyDecorator::GetCode_GetWorldRef()
+{
+	return TEXT("");
+}

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/AssetPropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/AssetPropertyDecorator.cpp
@@ -58,7 +58,7 @@ FString FAssetPropertyDecorator::GetCode_GetProtoFieldValueFrom(const FString& S
 
 FString FAssetPropertyDecorator::GetCode_SetProtoFieldValueTo(const FString& StateName, const FString& GetValueCode)
 {
-	return FString::Printf(TEXT("%s->mutable_%s()->CopyFrom(*ChanneldUtils::GetAssetByRef(%s))"), *StateName, *GetProtoFieldName(), *GetValueCode);
+	return FString::Printf(TEXT("%s->mutable_%s()->CopyFrom(ChanneldUtils::GetAssetRef(%s))"), *StateName, *GetProtoFieldName(), *GetValueCode);
 }
 
 FString FAssetPropertyDecorator::GetCode_SetPropertyValueTo(const FString& TargetInstance, const FString& NewStateName, const FString& AfterSetValueCode)

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/AssetPropertyDecoratorBuilder.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/AssetPropertyDecoratorBuilder.cpp
@@ -1,12 +1,19 @@
 #include "PropertyDecorator/AssetPropertyDecoratorBuilder.h"
 
+#include "GameFramework/WorldSettings.h"
+#include "PhysicsEngine/PhysicsAsset.h"
 #include "PropertyDecorator/AssetPropertyDecorator.h"
 
 bool FAssetPropertyDecoratorBuilder::IsSpecialProperty(FProperty* Property)
 {
 	if (Property->IsA<FObjectProperty>())
 	{
-		return Property->GetUPropertyWrapper()->GetClass()->ImplementsInterface(UInterface_AssetUserData::StaticClass());
+		const UClass* PropertyClass = CastFieldChecked<FObjectProperty>(Property)->PropertyClass;
+		return PropertyClass->IsAsset() || PropertyClass->IsChildOf<UPhysicsAsset>() ||
+			(PropertyClass->ImplementsInterface(UInterface_AssetUserData::StaticClass())
+				&& !PropertyClass->IsChildOf<UActorComponent>()
+				&& !PropertyClass->IsChildOf<AWorldSettings>()
+				&& !PropertyClass->IsChildOf<ULevel>());
 	}
 	return false;
 }

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/AssetPropertyDecoratorBuilder.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/AssetPropertyDecoratorBuilder.cpp
@@ -1,0 +1,17 @@
+#include "PropertyDecorator/AssetPropertyDecoratorBuilder.h"
+
+#include "PropertyDecorator/AssetPropertyDecorator.h"
+
+bool FAssetPropertyDecoratorBuilder::IsSpecialProperty(FProperty* Property)
+{
+	if (Property->IsA<FObjectProperty>())
+	{
+		return Property->GetUPropertyWrapper()->GetClass()->ImplementsInterface(UInterface_AssetUserData::StaticClass());
+	}
+	return false;
+}
+
+FPropertyDecorator* FAssetPropertyDecoratorBuilder::ConstructPropertyDecorator(FProperty* Property, IPropertyDecoratorOwner* InOwner)
+{
+	return new FAssetPropertyDecorator(Property, InOwner);
+}

--- a/Source/ReplicatorGenerator/Private/PropertyDecoratorFactory.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecoratorFactory.cpp
@@ -1,6 +1,7 @@
 ﻿#include "PropertyDecoratorFactory.h"
 
 #include "PropertyDecorator/ActorCompPropDecoratorBuilder.h"
+#include "PropertyDecorator/AssetPropertyDecoratorBuilder.h"
 #include "PropertyDecorator/BaseDataTypePropertyDecorator.h"
 #include "PropertyDecorator/RotatorPropertyDecoratorBuilder.h"
 #include "PropertyDecorator/VectorPropertyDecoratorBuilder.h"
@@ -24,6 +25,7 @@ FPropertyDecoratorFactory::FPropertyDecoratorFactory()
 		->SetNextBuilder(MakeShared<FRotatorPropertyDecoratorBuilder>())
 		->SetNextBuilder(MakeShared<FStructPropertyDecoratorBuilder>())
 		->SetNextBuilder(MakeShared<FActorCompPropDecoratorBuilder>())
+		->SetNextBuilder(MakeShared<FAssetPropertyDecoratorBuilder>())
 		->SetNextBuilder(MakeShared<FUObjPropertyDecoratorBuilder>());
 }
 

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator/AssetPropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator/AssetPropertyDecorator.h
@@ -1,0 +1,60 @@
+﻿#pragma once
+#include "PropertyDecorator.h"
+
+const static TCHAR* UAssetPropDeco_SetDeltaStateArrayInnerTemp =
+	LR"EOF(
+UObject * & PropItem = (*{Declare_PropertyPtr})[i];
+unrealpb::AssetRef* NewOne = {Declare_DeltaStateName}->add_{Definition_ProtoName}();
+*NewOne = ChanneldUtils::GetRefOfAsset(PropItem);
+if (!bPropChanged)
+{
+  bPropChanged = !(PropItem == ChanneldUtils::GetAssetByRef(&{Declare_FullStateName}->{Definition_ProtoName}()[i]));
+}
+)EOF";
+
+const static TCHAR* UAssetPropDeco_OnChangeStateArrayInnerTemp =
+	LR"EOF(
+UObject* NewAsset = ChanneldUtils::GetAssetByRef(&MessageArr[i]);
+if ((*{Declare_PropertyPtr})[i] != NewAsset)
+{
+  (*{Declare_PropertyPtr})[i] = NewAsset;
+  if (!bPropChanged)
+  {
+    bPropChanged = true;
+  }
+}
+)EOF";
+
+class FAssetPropertyDecorator : public FPropertyDecorator
+{
+public:
+	FAssetPropertyDecorator(FProperty* InProperty, IPropertyDecoratorOwner* InOwner)
+		: FPropertyDecorator(InProperty, InOwner)
+	{
+		bForceNotDirectlyAccessible = true;
+	}
+	virtual FString GetCPPType() override;
+
+	virtual FString GetPropertyType() override;
+	virtual FString GetProtoFieldType() override;
+	virtual FString GetProtoPackageName() override;
+	virtual FString GetProtoNamespace() override;
+	virtual FString GetProtoStateMessageType() override;
+
+	virtual FString GetCode_ActorPropEqualToProtoState(const FString& FromActor, const FString& FromState) override;
+	virtual FString GetCode_ActorPropEqualToProtoState(const FString& FromActor, const FString& FromState, bool ForceFromPointer) override;
+
+	virtual FString GetCode_GetProtoFieldValueFrom(const FString& StateName) override;
+
+	virtual FString GetCode_SetProtoFieldValueTo(const FString& StateName, const FString& GetValueCode) override;
+
+	virtual FString GetCode_SetPropertyValueTo(const FString& TargetInstance, const FString& NewStateName, const FString& AfterSetValueCode) override;
+	virtual FString GetCode_SetDeltaStateArrayInner(const FString& PropertyPointer, const FString& FullStateName, const FString& DeltaStateName, bool ConditionFullStateIsNull) override;
+
+	virtual FString GetCode_SetPropertyValueArrayInner(const FString& PropertyPointer, const FString& NewStateName) override;
+
+	virtual TArray<FString> GetAdditionalIncludes() override;
+
+	virtual FString GetCode_GetWorldRef() override;
+};
+

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator/AssetPropertyDecoratorBuilder.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator/AssetPropertyDecoratorBuilder.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "PropertyDecoratorBuilder.h"
+
+class FAssetPropertyDecoratorBuilder : public FPropertyDecoratorBuilder
+{
+public:
+	virtual bool IsSpecialProperty(FProperty*) override;
+
+protected:
+	virtual FPropertyDecorator* ConstructPropertyDecorator(FProperty*, IPropertyDecoratorOwner*) override;
+	
+};

--- a/Source/ReplicatorGenerator/Public/PropertyDecoratorBuilder.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecoratorBuilder.h
@@ -11,6 +11,7 @@ public:
 	virtual TSharedPtr<FPropertyDecoratorBuilder> SetNextBuilder(TSharedPtr<FPropertyDecoratorBuilder>&);
 	virtual TSharedPtr<FPropertyDecoratorBuilder> SetNextBuilder(TSharedPtr<FPropertyDecoratorBuilder>&&);
 
+	// Should we use a custom decorator for this type of property?
 	virtual bool IsSpecialProperty(FProperty*) = 0;
 
 	virtual FPropertyDecorator* GetPropertyDecorator(FProperty*, IPropertyDecoratorOwner*);


### PR DESCRIPTION
Support the replication of asset objects, including Animation, Skeleton, Level, Material, Sound, MovieSceneSequence, etc.

The replication code of properties with the types that implement `IInterface_AssetUserData` (except `ActorComponent`, `Level`, and `WorldSettings`) is now generated as they are `AssetRef`, not the `UnrealObjectRef`.