### PR TITLE
Fix Struct Property Decorator order

### DIFF
--- a/Source/ChanneldUE/Replication/ChanneldPlayerStateReplicator.cpp
+++ b/Source/ChanneldUE/Replication/ChanneldPlayerStateReplicator.cpp
@@ -22,11 +22,13 @@ FChanneldPlayerStateReplicator::FChanneldPlayerStateReplicator(UObject* InTarget
 		PlayerIdPtr = Property->ContainerPtrToValuePtr<int32>(PlayerState.Get());
 		check(PlayerIdPtr);
 	}
+#if ENGINE_MAJOR_VERSION < 5
 	{
 		auto Property = CastFieldChecked<const FByteProperty>(PlayerState->GetClass()->FindPropertyByName(FName("Ping")));
 		PingPtr = Property->ContainerPtrToValuePtr<uint8>(PlayerState.Get());
 		check(PingPtr);
 	}
+#endif
 }
 
 FChanneldPlayerStateReplicator::~FChanneldPlayerStateReplicator()

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator.cpp
@@ -209,7 +209,7 @@ FString FPropertyDecorator::GetCode_ActorPropEqualToProtoState(const FString& Fr
 FString FPropertyDecorator::GetCode_SetDeltaState(const FString& TargetInstance, const FString& FullStateName, const FString& DeltaStateName, bool ConditionFullStateIsNull)
 {
 	FStringFormatNamedArguments FormatArgs;
-	FormatArgs.Add(TEXT("Code_BeforeCondition"), ConditionFullStateIsNull ? TEXT("bIsFullStateNull ? true :") : TEXT(""));
+	FormatArgs.Add(TEXT("Code_BeforeCondition"), ConditionFullStateIsNull ? TEXT("bIsFullStateNull || ") : TEXT(""));
 	FormatArgs.Add(TEXT("Code_ActorPropEqualToProtoState"), GetCode_ActorPropEqualToProtoState(TargetInstance, FullStateName));
 	FormatArgs.Add(TEXT("Code_SetProtoFieldValue"), GetCode_SetProtoFieldValueTo(DeltaStateName, GetCode_GetPropertyValueFrom(TargetInstance)));
 	return FString::Format(PropDecorator_SetDeltaStateTemplate, FormatArgs);
@@ -225,7 +225,7 @@ FString FPropertyDecorator::GetCode_SetDeltaStateByMemOffset(const FString& Cont
 			FString::Printf(TEXT("%s* PropAddr"), *GetCPPType())
 		)
 	);
-	FormatArgs.Add(TEXT("Code_BeforeCondition"), ConditionFullStateIsNull ? TEXT("bIsFullStateNull ? true :") : TEXT(""));
+	FormatArgs.Add(TEXT("Code_BeforeCondition"), ConditionFullStateIsNull ? TEXT("bIsFullStateNull || ") : TEXT(""));
 	FormatArgs.Add(TEXT("Declare_PropertyPtr"), TEXT("PropAddr"));
 	FormatArgs.Add(TEXT("Code_GetProtoFieldValue"), GetCode_GetProtoFieldValueFrom(FullStateName));
 	FormatArgs.Add(TEXT("Code_SetProtoFieldValue"), GetCode_SetProtoFieldValueTo(DeltaStateName, TEXT("*PropAddr")));

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/ArrayPropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/ArrayPropertyDecorator.cpp
@@ -84,7 +84,7 @@ FString FArrayPropertyDecorator::GetCode_SetDeltaStateByMemOffset(const FString&
 	FormatArgs.Add(TEXT("Declare_ProtoStateMsgName"), Owner->GetProtoStateMessageType());
 	FormatArgs.Add(TEXT("Definition_ProtoName"), GetProtoFieldName());
 
-	FormatArgs.Add(TEXT("Code_BeforeCondition"), ConditionFullStateIsNull ? TEXT("bIsFullStateNull ? true :") : TEXT(""));
+	FormatArgs.Add(TEXT("Code_BeforeCondition"), ConditionFullStateIsNull ? TEXT("bIsFullStateNull || ") : TEXT(""));
 	FormatArgs.Add(TEXT("Code_GetProtoFieldValueFrom"), GetCode_GetProtoFieldValueFrom(TEXT("FullState")));
 	FormatArgs.Add(TEXT("Code_ConditionFullStateIsNull"), ConditionFullStateIsNull ? TEXT("bIsFullStateNull ? 0 : ") : TEXT(""));
 	FormatArgs.Add(
@@ -158,18 +158,18 @@ FString FArrayPropertyDecorator::GetCode_GetWorldRef()
 TArray<TSharedPtr<FStructPropertyDecorator>> FArrayPropertyDecorator::GetStructPropertyDecorators()
 {
 	TArray<TSharedPtr<FStructPropertyDecorator>> StructPropertyDecorators;
+	StructPropertyDecorators.Append(InnerProperty->GetStructPropertyDecorators());
 	if (InnerProperty->IsStruct())
 	{
 		StructPropertyDecorators.Add(StaticCastSharedPtr<FStructPropertyDecorator>(InnerProperty));
 	}
-	StructPropertyDecorators.Append(InnerProperty->GetStructPropertyDecorators());
 	TArray<TSharedPtr<FStructPropertyDecorator>> NonRepetitionStructPropertyDecorators;
-	TSet<FString> StructPropertyDecoratorNames;
+	TSet<FString> StructPropertyDecoratorFieldTypes;
 	for (TSharedPtr<FStructPropertyDecorator>& StructPropertyDecorator : StructPropertyDecorators)
 	{
-		if (!StructPropertyDecoratorNames.Contains(StructPropertyDecorator->GetPropertyName()))
+		if (!StructPropertyDecoratorFieldTypes.Contains(StructPropertyDecorator->GetProtoFieldType()))
 		{
-			StructPropertyDecoratorNames.Add(StructPropertyDecorator->GetPropertyName());
+			StructPropertyDecoratorFieldTypes.Add(StructPropertyDecorator->GetProtoFieldType());
 			NonRepetitionStructPropertyDecorators.Add(StructPropertyDecorator);
 		}
 	}

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/StructPropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/StructPropertyDecorator.cpp
@@ -290,19 +290,19 @@ TArray<TSharedPtr<FStructPropertyDecorator>> FStructPropertyDecorator::GetStruct
 	TArray<TSharedPtr<FStructPropertyDecorator>> StructPropertyDecorators;
 	for (TSharedPtr<FPropertyDecorator>& Property : Properties)
 	{
+		StructPropertyDecorators.Append(Property->GetStructPropertyDecorators());
 		if (Property->IsStruct())
 		{
 			StructPropertyDecorators.Add(StaticCastSharedPtr<FStructPropertyDecorator>(Property));
 		}
-		StructPropertyDecorators.Append(Property->GetStructPropertyDecorators());
 	}
 	TArray<TSharedPtr<FStructPropertyDecorator>> NonRepetitionStructPropertyDecorators;
-	TSet<FString> StructPropertyDecoratorNames;
+	TSet<FString> StructPropertyDecoratorFieldTypes;
 	for (TSharedPtr<FStructPropertyDecorator>& StructPropertyDecorator : StructPropertyDecorators)
 	{
-		if (!StructPropertyDecoratorNames.Contains(StructPropertyDecorator->GetPropertyName()))
+		if (!StructPropertyDecoratorFieldTypes.Contains(StructPropertyDecorator->GetProtoFieldType()))
 		{
-			StructPropertyDecoratorNames.Add(StructPropertyDecorator->GetPropertyName());
+			StructPropertyDecoratorFieldTypes.Add(StructPropertyDecorator->GetProtoFieldType());
 			NonRepetitionStructPropertyDecorators.Add(StructPropertyDecorator);
 		}
 	}

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/TextPropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/TextPropertyDecorator.cpp
@@ -35,7 +35,7 @@ FString FTextPropertyDecorator::GetCode_SetDeltaStateByMemOffset(const FString& 
 			FString::Printf(TEXT("%s* PropAddr"), *GetCPPType())
 		)
 	);
-	FormatArgs.Add(TEXT("Code_BeforeCondition"), ConditionFullStateIsNull ? TEXT("bIsFullStateNull ? true :") : TEXT(""));
+	FormatArgs.Add(TEXT("Code_BeforeCondition"), ConditionFullStateIsNull ? TEXT("bIsFullStateNull || ") : TEXT(""));
 	FormatArgs.Add(TEXT("Declare_PropertyPtr"), TEXT("PropAddr"));
 	FormatArgs.Add(TEXT("Code_GetProtoFieldValue"), GetCode_GetProtoFieldValueFrom(FullStateName));
 	FormatArgs.Add(TEXT("Code_SetProtoFieldValue"), GetCode_SetProtoFieldValueTo(DeltaStateName, TEXT("*PropAddr")));

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/VectorPropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/VectorPropertyDecorator.cpp
@@ -78,7 +78,7 @@ FString FVectorPropertyDecorator::GetCode_SetDeltaStateByMemOffset(const FString
 			FString::Printf(TEXT("%s* PropAddr"), *GetCPPType())
 		)
 	);
-	FormatArgs.Add(TEXT("Code_BeforeCondition"), ConditionFullStateIsNull ? TEXT("bIsFullStateNull ? true :") : TEXT(""));
+	FormatArgs.Add(TEXT("Code_BeforeCondition"), ConditionFullStateIsNull ? TEXT("bIsFullStateNull || ") : TEXT(""));
 	FormatArgs.Add(TEXT("Declare_PropertyPtr"), TEXT("PropAddr"));
 	FormatArgs.Add(TEXT("Code_GetProtoFieldValue"), GetCode_GetProtoFieldValueFrom(FullStateName));
 	FormatArgs.Add(TEXT("Code_SetProtoFieldValue"), GetCode_SetProtoFieldValueTo(DeltaStateName, TEXT("*PropAddr")));

--- a/Source/ReplicatorGenerator/Private/ReplicatedActorDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/ReplicatedActorDecorator.cpp
@@ -620,25 +620,25 @@ TArray<TSharedPtr<FStructPropertyDecorator>> FReplicatedActorDecorator::GetStruc
 	TArray<TSharedPtr<FStructPropertyDecorator>> StructPropertyDecorators;
 	for (TSharedPtr<FPropertyDecorator>& Property : Properties)
 	{
+		StructPropertyDecorators.Append(Property->GetStructPropertyDecorators());
 		if (Property->IsStruct())
 		{
 			StructPropertyDecorators.Add(StaticCastSharedPtr<FStructPropertyDecorator>(Property));
 		}
-		StructPropertyDecorators.Append(Property->GetStructPropertyDecorators());
 	}
 	for (TSharedPtr<FRPCDecorator> RPC : RPCs)
 	{
+		StructPropertyDecorators.Append(RPC->GetStructPropertyDecorators());
 		// The RPC parameters be seen as numbers of struct, so the RPC decorator be seen as a struct decorator. 
 		StructPropertyDecorators.Add(RPC);
-		StructPropertyDecorators.Append(RPC->GetStructPropertyDecorators());
 	}
 	TArray<TSharedPtr<FStructPropertyDecorator>> NonRepetitionStructPropertyDecorators;
-	TSet<FString> StructPropertyDecoratorNames;
+	TSet<FString> StructPropertyDecoratorFieldTypes;
 	for (TSharedPtr<FStructPropertyDecorator>& StructPropertyDecorator : StructPropertyDecorators)
 	{
-		if (!StructPropertyDecoratorNames.Contains(StructPropertyDecorator->GetPropertyName()))
+		if (!StructPropertyDecoratorFieldTypes.Contains(StructPropertyDecorator->GetProtoFieldType()))
 		{
-			StructPropertyDecoratorNames.Add(StructPropertyDecorator->GetPropertyName());
+			StructPropertyDecoratorFieldTypes.Add(StructPropertyDecorator->GetProtoFieldType());
 			NonRepetitionStructPropertyDecorators.Add(StructPropertyDecorator);
 		}
 	}

--- a/Source/ReplicatorGenerator/Private/ReplicatorCodeGenerator.cpp
+++ b/Source/ReplicatorGenerator/Private/ReplicatorCodeGenerator.cpp
@@ -169,8 +169,21 @@ bool FReplicatorCodeGenerator::Generate(
 	ReplicationCodeBundle.GlobalStructCodes.Append(FString::Printf(TEXT("#include \"%s\"\n"), *GenManager_GlobalStructProtoHeaderFile));
 	for (auto StructDecorator : GlobalStructDecorators)
 	{
+		if (StructDecorator->GetProtoFieldType().Contains(TEXT("RPCParams")))
+		{
+			continue;
+		}
 		ReplicationCodeBundle.GlobalStructCodes.Append(StructDecorator->GetDeclaration_PropPtrGroupStruct());
 		ReplicationCodeBundle.GlobalStructProtoDefinitions.Append(StructDecorator->GetDefinition_ProtoStateMessage());
+	}
+
+	for (auto StructDecorator : GlobalStructDecorators)
+	{
+		if (StructDecorator->GetProtoFieldType().Contains(TEXT("RPCParams")))
+		{
+			ReplicationCodeBundle.GlobalStructCodes.Append(StructDecorator->GetDeclaration_PropPtrGroupStruct());
+			ReplicationCodeBundle.GlobalStructProtoDefinitions.Append(StructDecorator->GetDefinition_ProtoStateMessage());
+		}
 	}
 
 	FStringFormatNamedArguments ProtoFormatArgs;
@@ -924,14 +937,15 @@ TArray<TSharedPtr<FStructPropertyDecorator>> FReplicatorCodeGenerator::GetAllStr
 		AllStructPropertyDecorators.Append(ActorDecoratorPtr->GetStructPropertyDecorators());
 	}
 	TArray<TSharedPtr<FStructPropertyDecorator>> NonRepetitionStructPropertyDecorators;
-	TSet<FString> StructPropertyDecoratorNames;
+	TSet<FString> StructPropertyDecoratorFieldTypes;
 	for (const TSharedPtr<FStructPropertyDecorator>& StructPropertyDecorator : AllStructPropertyDecorators)
 	{
-		if (StructPropertyDecoratorNames.Contains(StructPropertyDecorator->GetPropertyName()))
+		FString FieldType = StructPropertyDecorator->GetProtoFieldType();
+		if (StructPropertyDecoratorFieldTypes.Contains(FieldType))
 		{
 			continue;
 		}
-		StructPropertyDecoratorNames.Add(StructPropertyDecorator->GetPropertyName());
+		StructPropertyDecoratorFieldTypes.Add(FieldType);
 		NonRepetitionStructPropertyDecorators.Add(StructPropertyDecorator);
 	}
 	return NonRepetitionStructPropertyDecorators;

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator/UnrealObjectPropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator/UnrealObjectPropertyDecorator.h
@@ -5,7 +5,7 @@ const static TCHAR* UObjPropDeco_SetDeltaStateArrayInnerTemp =
 	LR"EOF(
 UObject * & PropItem = (*{Declare_PropertyPtr})[i];
 unrealpb::UnrealObjectRef* NewOne = {Declare_DeltaStateName}->add_{Definition_ProtoName}();
-*NewOne = ChanneldUtils::GetRefOfObject(PropItem);
+*NewOne = *ChanneldUtils::GetRefOfObject(PropItem);
 if (!bPropChanged)
 {
   bPropChanged = !(PropItem == ChanneldUtils::GetObjectByRef(&{Declare_FullStateName}->{Definition_ProtoName}()[i], {Code_GetWorldRef}));

--- a/Source/ReplicatorGenerator/Public/ReplicatorGeneratorUtils.h
+++ b/Source/ReplicatorGenerator/Public/ReplicatorGeneratorUtils.h
@@ -6,6 +6,15 @@
 
 namespace ChanneldReplicatorGeneratorUtils
 {
+	class IExternalTargetToGenerateChanneldDataFieldCallback
+	{
+	public:
+		virtual ~IExternalTargetToGenerateChanneldDataFieldCallback() {}
+		virtual bool ShouldGenerate(const UClass* TargetClass) const = 0;
+	};
+
+	extern TArray<TUniquePtr<IExternalTargetToGenerateChanneldDataFieldCallback>> ExternalTargetToGenerateChannelDataFieldList;
+
 	enum class EFilterRule: uint8
 	{
 		NeedToGenerateReplicator,
@@ -50,6 +59,8 @@ namespace ChanneldReplicatorGeneratorUtils
 	};
 
 	TSet<const UClass*> ChanneldUEBuiltinClassSet{ChanneldUEBuiltinClasses};
+
+	REPLICATORGENERATOR_API void AddTargetToGenerateChannelDataFieldCallback(IExternalTargetToGenerateChanneldDataFieldCallback* CB);
 
 	REPLICATORGENERATOR_API TArray<const UClass*> GetChanneldUEBuiltinClasses();
 


### PR DESCRIPTION
- Call GetStructPropertyDecorators first to fix the declaration order
- RPCParams declaration to the last

Other changes:
- Replace "bIsFullStateNull ? true :" with "bIsFullStateNull || "