### PR TITLE
Call RepNotify functions at the end of OnStateChanged

### DIFF
--- a/Source/ChanneldUE/Replication/ChanneldActorComponentReplicator.cpp
+++ b/Source/ChanneldUE/Replication/ChanneldActorComponentReplicator.cpp
@@ -68,12 +68,17 @@ void FChanneldActorComponentReplicator::OnStateChanged(const google::protobuf::M
 	if (NewState->has_bisactive())
 	{
 		ActorComponent->SetActiveFlag(NewState->bisactive());
-		ActorComponent->OnRep_IsActive();
 	}
 
 	if (NewState->has_breplicated())
 	{
 		ActorComponent->SetIsReplicated(NewState->breplicated());
+	}
+
+	// Process the RepNotify functions after all the replicated properties are updated.
+	if (NewState->has_bisactive())
+	{
+		ActorComponent->OnRep_IsActive();
 	}
 }
 

--- a/Source/ChanneldUE/Replication/ChanneldControllerReplicator.cpp
+++ b/Source/ChanneldUE/Replication/ChanneldControllerReplicator.cpp
@@ -96,7 +96,6 @@ void FChanneldControllerReplicator::OnStateChanged(const google::protobuf::Messa
 	if (NewState->has_playerstate())
 	{
 		Controller->PlayerState = Cast<APlayerState>(ChanneldUtils::GetObjectByRef(&NewState->playerstate(), Controller->GetWorld()));
-		Controller->OnRep_PlayerState();
 		UE_LOG(LogChanneld, Verbose, TEXT("Replicator set Controller's PlayerState to %s"), *GetNameSafe(Controller->PlayerState));
 	}
 
@@ -104,6 +103,11 @@ void FChanneldControllerReplicator::OnStateChanged(const google::protobuf::Messa
 	{
 		Controller->SetPawnFromRep(Cast<APawn>(ChanneldUtils::GetObjectByRef(&NewState->pawn(), Controller->GetWorld())));
 		UE_LOG(LogChanneld, Verbose, TEXT("Replicator set Controller's Pawn to %s"), *GetNameSafe(Controller->GetPawn()));
+	}
+	
+	if (NewState->has_playerstate())
+	{
+		Controller->OnRep_PlayerState();
 	}
 }
 

--- a/Source/ChanneldUE/Replication/ChanneldGameStateBaseReplicator.cpp
+++ b/Source/ChanneldUE/Replication/ChanneldGameStateBaseReplicator.cpp
@@ -26,6 +26,10 @@ FChanneldGameStateBaseReplicator::FChanneldGameStateBaseReplicator(UObject* InTa
 		bReplicatedHasBegunPlayPtr = Property->ContainerPtrToValuePtr<bool>(GameStateBase.Get());
 		check(bReplicatedHasBegunPlayPtr);
 	}
+	OnRep_GameModeClassFunc = GameStateBase->GetClass()->FindFunctionByName(FName("OnRep_GameModeClass"));
+	check(OnRep_GameModeClassFunc);
+	OnRep_SpectatorClassFunc = GameStateBase->GetClass()->FindFunctionByName(FName("OnRep_SpectatorClass"));
+	check(OnRep_SpectatorClassFunc);
 	OnRep_ReplicatedWorldTimeSecondsFunc = GameStateBase->GetClass()->FindFunctionByName(FName("OnRep_ReplicatedWorldTimeSeconds"));
 	check(OnRep_ReplicatedWorldTimeSecondsFunc);
 	OnRep_ReplicatedHasBegunPlayFunc = GameStateBase->GetClass()->FindFunctionByName(FName("OnRep_ReplicatedHasBegunPlay"));
@@ -120,24 +124,35 @@ void FChanneldGameStateBaseReplicator::OnStateChanged(const google::protobuf::Me
 	if (NewState->has_spectatorclassname())
 	{
 		GameStateBase->SpectatorClass = LoadClass<ASpectatorPawn>(NULL, UTF8_TO_TCHAR(NewState->spectatorclassname().c_str()));
-		GameStateBase->ReceivedSpectatorClass();
 	}
-
 	if (NewState->has_gamemodeclassname())
 	{
 		GameStateBase->GameModeClass = LoadClass<AGameModeBase>(NULL, UTF8_TO_TCHAR(NewState->gamemodeclassname().c_str()));
-		GameStateBase->ReceivedGameModeClass();
 	}
-
 	if (NewState->has_replicatedworldtimeseconds())
 	{
 		*ReplicatedWorldTimeSecondsPtr = NewState->replicatedworldtimeseconds();
-		GameStateBase->ProcessEvent(OnRep_ReplicatedWorldTimeSecondsFunc, NULL);
 	}
 	if (NewState->has_breplicatedhasbegunplay())
 	{
 		*bReplicatedHasBegunPlayPtr = NewState->breplicatedhasbegunplay();
-		GameStateBase->ProcessEvent(OnRep_ReplicatedHasBegunPlayFunc, NULL);
+	}
+
+	if (NewState->has_spectatorclassname())
+	{
+		GameStateBase->ProcessEvent(OnRep_GameModeClassFunc, nullptr);
+	}
+	if (NewState->has_gamemodeclassname())
+	{
+		GameStateBase->ProcessEvent(OnRep_SpectatorClassFunc, nullptr);
+	}
+	if (NewState->has_replicatedworldtimeseconds())
+	{
+		GameStateBase->ProcessEvent(OnRep_ReplicatedWorldTimeSecondsFunc, nullptr);
+	}
+	if (NewState->has_breplicatedhasbegunplay())
+	{
+		GameStateBase->ProcessEvent(OnRep_ReplicatedHasBegunPlayFunc, nullptr);
 	}
 }
 

--- a/Source/ChanneldUE/Replication/ChanneldGameStateBaseReplicator.h
+++ b/Source/ChanneldUE/Replication/ChanneldGameStateBaseReplicator.h
@@ -30,6 +30,8 @@ protected:
 private:
 	float* ReplicatedWorldTimeSecondsPtr;
 	bool* bReplicatedHasBegunPlayPtr;
+	UFunction* OnRep_GameModeClassFunc;
+	UFunction* OnRep_SpectatorClassFunc;
 	UFunction* OnRep_ReplicatedWorldTimeSecondsFunc;
 	UFunction* OnRep_ReplicatedHasBegunPlayFunc;
 };

--- a/Source/ChanneldUE/Replication/ChanneldPawnReplicator.cpp
+++ b/Source/ChanneldUE/Replication/ChanneldPawnReplicator.cpp
@@ -115,10 +115,10 @@ void FChanneldPawnReplicator::OnStateChanged(const google::protobuf::Message* In
 	if (NewState->has_playerstate())
 	{
 		*PlayerStatePtr = Cast<APlayerState>(ChanneldUtils::GetObjectByRef(&NewState->playerstate(), Pawn->GetWorld()));
-		Pawn->OnRep_PlayerState();
 		UE_LOG(LogChanneld, Verbose, TEXT("Replicator set Pawn's PlayerState to %s"), *GetNameSafe(*PlayerStatePtr));
 	}
 
+	bool bShouldCallOnRepController= false;
 	if (NewState->has_controller())
 	{
 		Pawn->Controller = Cast<AController>(ChanneldUtils::GetObjectByRef(&NewState->controller(), Pawn->GetWorld()));
@@ -127,12 +127,12 @@ void FChanneldPawnReplicator::OnStateChanged(const google::protobuf::Message* In
 			// Special case: the PlayerController is under destruction, so calling OnRep_Controller() will cause crash
 			if (PC->PlayerCameraManager)
 			{
-				Pawn->OnRep_Controller();
+				bShouldCallOnRepController = true;
 			}
 		}
 		else
 		{
-			Pawn->OnRep_Controller();
+			bShouldCallOnRepController = true;
 		}
 		UE_LOG(LogChanneld, Verbose, TEXT("Replicator set Pawn's Controller to %s"), *GetNameSafe(Pawn->Controller));
 	}
@@ -140,5 +140,14 @@ void FChanneldPawnReplicator::OnStateChanged(const google::protobuf::Message* In
 	if (NewState->has_remoteviewpitch())
 	{
 		Pawn->RemoteViewPitch = NewState->remoteviewpitch();
+	}
+
+	if (NewState->has_playerstate())
+	{
+		Pawn->OnRep_PlayerState();
+	}
+	if (bShouldCallOnRepController)
+	{
+		Pawn->OnRep_Controller();
 	}
 }

--- a/Source/ChanneldUE/Replication/ChanneldPlayerStateReplicator.cpp
+++ b/Source/ChanneldUE/Replication/ChanneldPlayerStateReplicator.cpp
@@ -108,12 +108,10 @@ void FChanneldPlayerStateReplicator::OnStateChanged(const google::protobuf::Mess
 	if (NewState->has_score())
 	{
 		*ScorePtr = NewState->score();
-		PlayerState->OnRep_Score();
 	}
 	if (NewState->has_playerid())
 	{
 		*PlayerIdPtr = NewState->playerid();
-		PlayerState->OnRep_PlayerId();
 	}
 	if (NewState->has_ping())
 	{
@@ -122,6 +120,15 @@ void FChanneldPlayerStateReplicator::OnStateChanged(const google::protobuf::Mess
 	if (NewState->has_playername())
 	{
 		PlayerState->SetPlayerName(FString(UTF8_TO_TCHAR(NewState->playername().c_str())));
+	}
+
+	if (NewState->has_score())
+	{
+		PlayerState->OnRep_Score();
+	}
+	if (NewState->has_playerid())
+	{
+		PlayerState->OnRep_PlayerId();
 	}
 }
 

--- a/Source/ChanneldUE/Replication/ChanneldPlayerStateReplicator.h
+++ b/Source/ChanneldUE/Replication/ChanneldPlayerStateReplicator.h
@@ -5,6 +5,7 @@
 #include "GameFramework/PlayerState.h"
 #include "unreal_common.pb.h"
 
+// Deprecated: Missing some properties like UniqueId, PlayerName, etc. Will be replaced with the generated code.
 class CHANNELDUE_API FChanneldPlayerStateReplicator : public FChanneldReplicatorBase
 {
 public:

--- a/Source/ChanneldUE/Replication/ChanneldReplication.cpp
+++ b/Source/ChanneldUE/Replication/ChanneldReplication.cpp
@@ -109,7 +109,7 @@ TArray<FChanneldReplicatorBase*> ChanneldReplication::FindAndCreateReplicators(U
 		auto Replicator = (*Func)(ReplicatedObj);
 		UE_LOG(LogChanneld, Verbose, TEXT("Created %sReplicator for object: %s"), *Class->GetName(), *ReplicatedObj->GetName());
 		// Add the replicators in the order as base class -> inherited class (e.g. Actor->GameStateBase),
-		// to make sure the property replication and OnRep functions are executed in the right order (e.g. Actor.Role -> GameStateBase.bReplicatedHasBegunPlay -> NotifyBeginPlay())
+		// to make sure the property updates are executed in the right order (e.g. Actor.Role -> GameStateBase.bReplicatedHasBegunPlay)
 		Result.Insert(Replicator, 0);
 	}
 

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator.cpp
@@ -253,6 +253,7 @@ FString FPropertyDecorator::GetCode_CallRepNotify(const FString& TargetInstanceN
 	if (OriginalProperty->HasAnyPropertyFlags(CPF_RepNotify))
 	{
 		FStringFormatNamedArguments FormatArgs;
+		FormatArgs.Add(TEXT("Declare_PropertyName"), GetPropertyName());
 		FormatArgs.Add(TEXT("Declare_TargetInstance"), TargetInstanceName);
 		FormatArgs.Add(TEXT("Declare_FunctionName"), OriginalProperty->RepNotifyFunc.ToString());
 		const UFunction* RepNotifyFunc = Owner->FindFunctionByName(OriginalProperty->RepNotifyFunc);
@@ -262,20 +263,14 @@ FString FPropertyDecorator::GetCode_CallRepNotify(const FString& TargetInstanceN
 	return TEXT("");
 }
 
-FString FPropertyDecorator::GetCode_OnStateChange(const FString& TargetInstanceName, const FString& NewStateName, bool NeedCallRepNotify)
+FString FPropertyDecorator::GetCode_OnStateChange(const FString& TargetInstanceName, const FString& NewStateName, const FString& AfterSetValueCode)
 {
 	FStringFormatNamedArguments FormatArgs;
 	FormatArgs.Add(TEXT("Code_HasProtoFieldValue"), GetCode_HasProtoFieldValueIn(NewStateName));
 	FormatArgs.Add(TEXT("Code_ActorPropEqualToProtoState"), GetCode_ActorPropEqualToProtoState(TargetInstanceName, NewStateName));
 	FormatArgs.Add(
-		TEXT("Code_SetPropertyValue"),
-		(NeedCallRepNotify && HasOnRepNotifyParam()
-			 ? FString::Printf(TEXT("auto OldValue = %s;\n"), *GetCode_GetPropertyValueFrom(TargetInstanceName))
-			 : "")
-		.Append(GetCode_SetPropertyValueTo(
-			TargetInstanceName, NewStateName,
-			NeedCallRepNotify ? GetCode_CallRepNotify(TargetInstanceName, TEXT("&OldValue")) : TEXT("")
-		))
+	TEXT("Code_SetPropertyValue"),
+		GetCode_SetPropertyValueTo(TargetInstanceName, NewStateName, AfterSetValueCode)
 	);
 	return FString::Format(PropDecorator_OnChangeStateTemplate, FormatArgs);
 }
@@ -299,6 +294,7 @@ FString FPropertyDecorator::GetCode_OnStateChangeByMemOffset(const FString& Cont
 FString FPropertyDecorator::GetCode_SetPropertyValueArrayInner(const FString& PropertyPointer, const FString& NewStateName)
 {
 	FStringFormatNamedArguments FormatArgs;
+	FormatArgs.Add(TEXT("Declare_PropertyName"), GetPropertyName());
 	FormatArgs.Add(TEXT("Declare_PropertyPtr"), PropertyPointer);
 	return FString::Format(PropDeco_OnChangeStateArrayInnerTemp, FormatArgs);
 }

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator.cpp
@@ -291,10 +291,10 @@ FString FPropertyDecorator::GetCode_OnStateChangeByMemOffset(const FString& Cont
 	return FString::Format(PropDeco_OnChangeStateByMemOffsetTemp, FormatArgs);
 }
 
-FString FPropertyDecorator::GetCode_SetPropertyValueArrayInner(const FString& PropertyPointer, const FString& NewStateName)
+FString FPropertyDecorator::GetCode_SetPropertyValueArrayInner(const FString& ArrayPropertyName, const FString& PropertyPointer, const FString& NewStateName)
 {
 	FStringFormatNamedArguments FormatArgs;
-	FormatArgs.Add(TEXT("Declare_PropertyName"), GetPropertyName());
+	FormatArgs.Add(TEXT("Declare_PropertyName"), ArrayPropertyName);
 	FormatArgs.Add(TEXT("Declare_PropertyPtr"), PropertyPointer);
 	return FString::Format(PropDeco_OnChangeStateArrayInnerTemp, FormatArgs);
 }

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator.cpp
@@ -157,7 +157,7 @@ FString FPropertyDecorator::GetCode_GetPropertyValueFrom(const FString& TargetIn
 
 FString FPropertyDecorator::GetCode_SetPropertyValueTo(const FString& TargetInstance, const FString& NewStateName, const FString& AfterSetValueCode)
 {
-	return FString::Printf(TEXT("%s = %s;\nbStateChanged = true;\n%s"), *GetCode_GetPropertyValueFrom(TargetInstance), *GetCode_GetProtoFieldValueFrom(NewStateName), *AfterSetValueCode);
+	return FString::Printf(TEXT("%s = %s;\n%s"), *GetCode_GetPropertyValueFrom(TargetInstance), *GetCode_GetProtoFieldValueFrom(NewStateName), *AfterSetValueCode);
 }
 
 FString FPropertyDecorator::GetDeclaration_PropertyPtr()

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/ActorCompPropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/ActorCompPropertyDecorator.cpp
@@ -62,9 +62,10 @@ FString FActorCompPropertyDecorator::GetCode_SetDeltaStateArrayInner(const FStri
 	return FString::Format(ActorCompPropDeco_SetDeltaStateArrayInnerTemp, FormatArgs);
 }
 
-FString FActorCompPropertyDecorator::GetCode_SetPropertyValueArrayInner(const FString& PropertyPointer, const FString& NewStateName)
+FString FActorCompPropertyDecorator::GetCode_SetPropertyValueArrayInner(const FString& ArrayPropertyName, const FString& PropertyPointer, const FString& NewStateName)
 {
 	FStringFormatNamedArguments FormatArgs;
+	FormatArgs.Add(TEXT("Declare_PropertyName"), ArrayPropertyName);
 	FormatArgs.Add(TEXT("Declare_PropertyPtr"), PropertyPointer);
 	FormatArgs.Add(TEXT("Code_GetWorldRef"), Owner->GetCode_GetWorldRef());
 	return FString::Format(ActorCompPropDeco_OnChangeStateArrayInnerTemp, FormatArgs);

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/ArrayPropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/ArrayPropertyDecorator.cpp
@@ -121,7 +121,7 @@ FString FArrayPropertyDecorator::GetCode_SetPropertyValueTo(const FString& Targe
 	FormatArgs.Add(TEXT("Declare_PropertyName"), GetPropertyName());
 	FormatArgs.Add(TEXT("Declare_PropPtrName"), GetPointerName());
 	FormatArgs.Add(TEXT("Code_GetProtoFieldValueFrom"), GetCode_GetProtoFieldValueFrom(NewStateName));
-	FormatArgs.Add(TEXT("Code_SetPropertyValueArrayInner"), InnerProperty->GetCode_SetPropertyValueArrayInner(GetPointerName(), NewStateName));
+	FormatArgs.Add(TEXT("Code_SetPropertyValueArrayInner"), InnerProperty->GetCode_SetPropertyValueArrayInner(GetPropertyName(), GetPointerName(), NewStateName));
 
 	return FString::Format(ArrPropDeco_SetPropertyValueTemp, FormatArgs);
 }
@@ -138,7 +138,7 @@ FString FArrayPropertyDecorator::GetCode_OnStateChangeByMemOffset(const FString&
 	);
 	FormatArgs.Add(TEXT("Declare_PropPtrName"), TEXT("PropAddr"));
 	FormatArgs.Add(TEXT("Code_GetProtoFieldValueFrom"), GetCode_GetProtoFieldValueFrom(NewStateName));
-	FormatArgs.Add(TEXT("Code_SetPropertyValueArrayInner"), InnerProperty->GetCode_SetPropertyValueArrayInner(TEXT("PropAddr"), NewStateName));
+	FormatArgs.Add(TEXT("Code_SetPropertyValueArrayInner"), InnerProperty->GetCode_SetPropertyValueArrayInner(TEXT("Prop"), TEXT("PropAddr"), NewStateName));
 
 	return FString::Format(ArrPropDeco_SetPropertyValueByMemOffsetTemp, FormatArgs);
 }

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/ArrayPropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/ArrayPropertyDecorator.cpp
@@ -99,13 +99,9 @@ FString FArrayPropertyDecorator::GetCode_HasProtoFieldValueIn(const FString& Sta
 	return FString::Printf(TEXT("%s.size() > 0"), *GetCode_GetProtoFieldValueFrom(StateName));
 }
 
-FString FArrayPropertyDecorator::GetCode_OnStateChange(const FString& TargetInstanceName, const FString& NewStateName, bool NeedCallRepNotify)
+FString FArrayPropertyDecorator::GetCode_OnStateChange(const FString& TargetInstanceName, const FString& NewStateName, const FString& AfterSetValueCode)
 {
 	FStringFormatNamedArguments FormatArgs;
-	if(NeedCallRepNotify && HasOnRepNotifyParam())
-	{
-		FormatArgs.Add(TEXT("Definition_OldValue"), FString::Printf(TEXT("auto OldValue = %s;\n"), *GetCode_GetPropertyValueFrom(TargetInstanceName)));
-	}
 	FormatArgs.Add(TEXT("Code_HasProtoFieldValue"), GetCode_HasProtoFieldValueIn(NewStateName));
 	FormatArgs.Add(
 		TEXT("Code_SetPropertyValue"),
@@ -113,18 +109,16 @@ FString FArrayPropertyDecorator::GetCode_OnStateChange(const FString& TargetInst
 			TargetInstanceName, NewStateName, TEXT("")
 		)
 	);
+	FormatArgs.Add(TEXT("Declare_PropertyName"), GetPropertyName());
 	FormatArgs.Add(TEXT("Declare_PropPtrName"), GetPointerName());
 	FormatArgs.Add(TEXT("Code_GetProtoFieldValueFrom"), GetCode_GetProtoFieldValueFrom(NewStateName));
-	FormatArgs.Add(
-		TEXT("Code_CallRepNotify"),
-		NeedCallRepNotify ? GetCode_CallRepNotify(TargetInstanceName, TEXT("&OldValue")) : TEXT("")
-	);
 	return FString::Format(ArrPropDeco_OnChangeStateTemp, FormatArgs);
 }
 
 FString FArrayPropertyDecorator::GetCode_SetPropertyValueTo(const FString& TargetInstance, const FString& NewStateName, const FString& AfterSetValueCode)
 {
 	FStringFormatNamedArguments FormatArgs;
+	FormatArgs.Add(TEXT("Declare_PropertyName"), GetPropertyName());
 	FormatArgs.Add(TEXT("Declare_PropPtrName"), GetPointerName());
 	FormatArgs.Add(TEXT("Code_GetProtoFieldValueFrom"), GetCode_GetProtoFieldValueFrom(NewStateName));
 	FormatArgs.Add(TEXT("Code_SetPropertyValueArrayInner"), InnerProperty->GetCode_SetPropertyValueArrayInner(GetPointerName(), NewStateName));

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/NamePropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/NamePropertyDecorator.cpp
@@ -25,9 +25,10 @@ FString FNamePropertyDecorator::GetCode_SetDeltaStateArrayInner(const FString& P
 	return FString::Format(NamePropDeco_SetDeltaStateArrayInnerTemp, FormatArgs);
 }
 
-FString FNamePropertyDecorator::GetCode_SetPropertyValueArrayInner(const FString& PropertyPointer, const FString& NewStateName)
+FString FNamePropertyDecorator::GetCode_SetPropertyValueArrayInner(const FString& ArrayPropertyName, const FString& PropertyPointer, const FString& NewStateName)
 {
 	FStringFormatNamedArguments FormatArgs;
+	FormatArgs.Add(TEXT("Declare_PropertyName"), ArrayPropertyName);
 	FormatArgs.Add(TEXT("Declare_PropertyPtr"), PropertyPointer);
 	return FString::Format(NamePropDeco_OnChangeStateArrayInnerTemp, FormatArgs);
 }

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/StringPropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/StringPropertyDecorator.cpp
@@ -25,9 +25,10 @@ FString FStringPropertyDecorator::GetCode_SetDeltaStateArrayInner(const FString&
 	return FString::Format(StrPropDeco_SetDeltaStateArrayInnerTemp, FormatArgs);
 }
 
-FString FStringPropertyDecorator::GetCode_SetPropertyValueArrayInner(const FString& PropertyPointer, const FString& NewStateName)
+FString FStringPropertyDecorator::GetCode_SetPropertyValueArrayInner(const FString& ArrayPropertyName, const FString& PropertyPointer, const FString& NewStateName)
 {
 	FStringFormatNamedArguments FormatArgs;
+	FormatArgs.Add(TEXT("Declare_PropertyName"), ArrayPropertyName);
 	FormatArgs.Add(TEXT("Declare_PropertyPtr"), PropertyPointer);
 	return FString::Format(StrPropDeco_OnChangeStateArrayInnerTemp, FormatArgs);
 }

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/StructPropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/StructPropertyDecorator.cpp
@@ -147,9 +147,10 @@ FString FStructPropertyDecorator::GetCode_OnStateChangeByMemOffset(const FString
 	);
 }
 
-FString FStructPropertyDecorator::GetCode_SetPropertyValueArrayInner(const FString& PropertyPointer, const FString& NewStateName)
+FString FStructPropertyDecorator::GetCode_SetPropertyValueArrayInner(const FString& ArrayPropertyName, const FString& PropertyPointer, const FString& NewStateName)
 {
 	FStringFormatNamedArguments FormatArgs;
+	FormatArgs.Add(TEXT("Declare_PropertyName"), ArrayPropertyName);
 	FormatArgs.Add(TEXT("Declare_PropertyPtr"), PropertyPointer);
 	FormatArgs.Add(TEXT("Declare_PropPtrGroupStructName"), GetDeclaration_PropPtrGroupStructName());
 	FormatArgs.Add(TEXT("Code_GetWorldRef"), Owner->GetCode_GetWorldRef());

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/TextPropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/TextPropertyDecorator.cpp
@@ -67,9 +67,10 @@ FString FTextPropertyDecorator::GetCode_OnStateChangeByMemOffset(const FString& 
 	FormatArgs.Add(TEXT("Code_GetProtoFieldValue"), GetCode_GetProtoFieldValueFrom(NewStateName));
 	return FString::Format(TextPropDeco_OnChangeStateByMemOffsetTemp, FormatArgs);
 }
-FString FTextPropertyDecorator::GetCode_SetPropertyValueArrayInner(const FString& PropertyPointer, const FString& NewStateName)
+FString FTextPropertyDecorator::GetCode_SetPropertyValueArrayInner(const FString& ArrayPropertyName, const FString& PropertyPointer, const FString& NewStateName)
 {
 	FStringFormatNamedArguments FormatArgs;
+	FormatArgs.Add(TEXT("Declare_PropertyName"), ArrayPropertyName);
 	FormatArgs.Add(TEXT("Declare_PropertyPtr"), PropertyPointer);
 	return FString::Format(TextPropDeco_OnChangeStateArrayInnerTemp, FormatArgs);
 }

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/UnrealObjectPropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/UnrealObjectPropertyDecorator.cpp
@@ -82,9 +82,10 @@ FString FUnrealObjectPropertyDecorator::GetCode_SetDeltaStateArrayInner(const FS
 	return FString::Format(UObjPropDeco_SetDeltaStateArrayInnerTemp, FormatArgs);
 }
 
-FString FUnrealObjectPropertyDecorator::GetCode_SetPropertyValueArrayInner(const FString& PropertyPointer, const FString& NewStateName)
+FString FUnrealObjectPropertyDecorator::GetCode_SetPropertyValueArrayInner(const FString& ArrayPropertyName, const FString& PropertyPointer, const FString& NewStateName)
 {
 	FStringFormatNamedArguments FormatArgs;
+	FormatArgs.Add(TEXT("Declare_PropertyName"), ArrayPropertyName);
 	FormatArgs.Add(TEXT("Declare_PropertyPtr"), PropertyPointer);
 	FormatArgs.Add(TEXT("Code_GetWorldRef"), Owner->GetCode_GetWorldRef());
 	return FString::Format(UObjPropDeco_OnChangeStateArrayInnerTemp, FormatArgs);

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/VectorPropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/VectorPropertyDecorator.cpp
@@ -115,9 +115,10 @@ FString FVectorPropertyDecorator::GetCode_OnStateChangeByMemOffset(const FString
 	return FString::Format(VectorPropDeco_OnChangeStateByMemOffsetTemp, FormatArgs);
 }
 
-FString FVectorPropertyDecorator::GetCode_SetPropertyValueArrayInner(const FString& PropertyPointer, const FString& NewStateName)
+FString FVectorPropertyDecorator::GetCode_SetPropertyValueArrayInner(const FString& ArrayPropertyName, const FString& PropertyPointer, const FString& NewStateName)
 {
 	FStringFormatNamedArguments FormatArgs;
+	FormatArgs.Add(TEXT("Declare_PropertyName"), ArrayPropertyName);
 	FormatArgs.Add(TEXT("Declare_PropertyPtr"), PropertyPointer);
 	FormatArgs.Add(TEXT("FunctionName_SetXXXFromPB"), GetFunctionName_SetXXXFromPB());
 	return FString::Format(VectorPropDeco_OnChangeStateArrayInnerTemp, FormatArgs);

--- a/Source/ReplicatorGenerator/Private/ReplicatedActorDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/ReplicatedActorDecorator.cpp
@@ -332,7 +332,7 @@ FString FReplicatedActorDecorator::GetCode_AllPropertiesOnStateChange(const FStr
 		if (Property->HasOnRepNotifyParam())
 		{
 			// `Old{PropertyName}` variable is used to pass the old property value to OnRep() function.
-			OnChangeStateCodeBuilder.Append(FString::Printf(TEXT("auto Old%s = %s;\n"),
+			OnChangeStateCodeBuilder.Append(FString::Printf(TEXT("auto Old%s = %s;"),
 				*Property->GetPropertyName(), *Property->GetCode_GetPropertyValueFrom(InstanceRefName)));
 		}
 		OnChangeStateCodeBuilder.Append(Property->GetCode_OnStateChange(InstanceRefName, NewStateName,

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator.h
@@ -45,7 +45,10 @@ if (!bPropChanged)
 
 const static TCHAR* PropDecorator_CallRepNotifyTemplate =
 	LR"EOF(
-{Declare_TargetInstance}->ProcessEvent({Declare_TargetInstance}->GetClass()->FindFunctionByName(FName(TEXT("{Declare_FunctionName}"))), {Code_OnRepParams});
+if (b{Declare_PropertyName}Changed)
+{
+	{Declare_TargetInstance}->ProcessEvent({Declare_TargetInstance}->GetClass()->FindFunctionByName(FName(TEXT("{Declare_FunctionName}"))), {Code_OnRepParams});
+}
 )EOF";
 
 
@@ -74,9 +77,9 @@ const static TCHAR* PropDeco_OnChangeStateArrayInnerTemp =
 if ((*{Declare_PropertyPtr})[i] != MessageArr[i])
 {
   (*{Declare_PropertyPtr})[i] = MessageArr[i];
-  if (!bPropChanged)
+  if (!b{Declare_PropertyName}Changed)
   {
-    bPropChanged = true;
+    b{Declare_PropertyName}Changed = true;
   }
 }
 )EOF";
@@ -279,7 +282,7 @@ public:
 	 *     Character->bIsCrouched = NewState->biscrouched();
 	 *   }
 	 */
-	virtual FString GetCode_OnStateChange(const FString& TargetInstanceName, const FString& NewStateName, bool NeedCallRepNotify = false);
+	virtual FString GetCode_OnStateChange(const FString& TargetInstanceName, const FString& NewStateName, const FString& AfterSetValueCode = TEXT(""));
 
 	virtual FString GetCode_OnStateChangeByMemOffset(const FString& ContainerName, const FString& NewStateName);
 

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator.h
@@ -286,7 +286,7 @@ public:
 
 	virtual FString GetCode_OnStateChangeByMemOffset(const FString& ContainerName, const FString& NewStateName);
 
-	virtual FString GetCode_SetPropertyValueArrayInner(const FString& PropertyPointer, const FString& NewStateName);
+	virtual FString GetCode_SetPropertyValueArrayInner(const FString& ArrayPropertyName, const FString& PropertyPointer, const FString& NewStateName);
 
 	virtual TArray<FString> GetAdditionalIncludes() override;
 

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator/ActorCompPropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator/ActorCompPropertyDecorator.h
@@ -18,9 +18,9 @@ UActorComponent* NewCompRef = ChanneldUtils::GetActorComponentByRef(&MessageArr[
 if ((*{Declare_PropertyPtr})[i] != NewCompRef)
 {
   (*{Declare_PropertyPtr})[i] = NewCompRef;
-  if (!bPropChanged)
+  if (!b{Declare_PropertyName}Changed)
   {
-    bPropChanged = true;
+    b{Declare_PropertyName}Changed = true;
   }
 }
 )EOF";
@@ -46,6 +46,6 @@ public:
 	virtual FString GetCode_SetPropertyValueTo(const FString& TargetInstance, const FString& NewStateName, const FString& AfterSetValueCode) override;
 	virtual FString GetCode_SetDeltaStateArrayInner(const FString& PropertyPointer, const FString& FullStateName, const FString& DeltaStateName, bool ConditionFullStateIsNull) override;
 
-	virtual FString GetCode_SetPropertyValueArrayInner(const FString& PropertyPointer, const FString& NewStateName) override;
+	virtual FString GetCode_SetPropertyValueArrayInner(const FString& ArrayPropertyName, const FString& PropertyPointer, const FString& NewStateName) override;
 
 };

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator/ArrayPropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator/ArrayPropertyDecorator.h
@@ -70,10 +70,6 @@ else
 b{Declare_PropertyName}Changed = {Declare_PropPtrName}->Num() != {Code_GetProtoFieldValueFrom}.size();
 {Declare_PropPtrName}->Empty();
 }
-if(b{Declare_PropertyName}Changed)
-{
-bStateChanged = true;
-}
 )EOF";
 
 const static TCHAR* ArrPropDeco_SetPropertyValueTemp =

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator/ArrayPropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator/ArrayPropertyDecorator.h
@@ -61,23 +61,18 @@ const static TCHAR* ArrPropDeco_SetDeltaStateByMemOffsetTemp =
 
 const static TCHAR* ArrPropDeco_OnChangeStateTemp =
 	LR"EOF(
+if ({Code_HasProtoFieldValue})
 {
-  bool bPropChanged = false;
-  {Definition_OldValue}
-  if ({Code_HasProtoFieldValue})
-  {
-    {Code_SetPropertyValue}
-  }
-  else 
-  {
-    bPropChanged = {Declare_PropPtrName}->Num() != {Code_GetProtoFieldValueFrom}.size();
-    {Declare_PropPtrName}->Empty();
-  }
-  if(bPropChanged)
-  {
-    bStateChanged = true;
-    {Code_CallRepNotify}
-  }
+{Code_SetPropertyValue}
+}
+else 
+{
+b{Declare_PropertyName}Changed = {Declare_PropPtrName}->Num() != {Code_GetProtoFieldValueFrom}.size();
+{Declare_PropPtrName}->Empty();
+}
+if(b{Declare_PropertyName}Changed)
+{
+bStateChanged = true;
 }
 )EOF";
 
@@ -88,7 +83,7 @@ auto & MessageArr = {Code_GetProtoFieldValueFrom};
 const int32 NewStateValueLength = MessageArr.size();
 if (ActorPropLength != NewStateValueLength)
 { 
-  bPropChanged = true; 
+  b{Declare_PropertyName}Changed = true; 
 }
 {Declare_PropPtrName}->SetNum(NewStateValueLength);
 for (int32 i = 0; i < NewStateValueLength; ++i)
@@ -145,7 +140,7 @@ public:
 
 	virtual FString GetCode_HasProtoFieldValueIn(const FString& StateName) override;
 
-	virtual FString GetCode_OnStateChange(const FString& TargetInstanceName, const FString& NewStateName, bool NeedCallRepNotify = false) override;
+	virtual FString GetCode_OnStateChange(const FString& TargetInstanceName, const FString& NewStateName, const FString& AfterSetValueCode) override;
 	virtual FString GetCode_SetPropertyValueTo(const FString& TargetInstance, const FString& NewStateName, const FString& AfterSetValueCode) override;
 	virtual FString GetCode_OnStateChangeByMemOffset(const FString& ContainerName, const FString& NewStateName) override;
 

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator/NamePropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator/NamePropertyDecorator.h
@@ -18,9 +18,9 @@ FName NewName = FName(UTF8_TO_TCHAR(MessageArr[i].c_str()));
 if ((*{Declare_PropertyPtr})[i] != NewName)
 {
   (*{Declare_PropertyPtr})[i] = NewName;
-  if (!bPropChanged)
+  if (!b{Declare_PropertyName}Changed)
   {
-    bPropChanged = true;
+    b{Declare_PropertyName}Changed = true;
   }
 }
 )EOF";
@@ -42,6 +42,6 @@ public:
 
 	virtual FString GetCode_SetDeltaStateArrayInner(const FString& PropertyPointer, const FString& FullStateName, const FString& DeltaStateName, bool ConditionFullStateIsNull) override;
 
-	virtual FString GetCode_SetPropertyValueArrayInner(const FString& PropertyPointer, const FString& NewStateName) override;
+	virtual FString GetCode_SetPropertyValueArrayInner(const FString& ArrayPropertyName, const FString& PropertyPointer, const FString& NewStateName) override;
 
 };

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator/RotatorPropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator/RotatorPropertyDecorator.h
@@ -18,9 +18,9 @@ FRotator NewVector = ChanneldUtils::GetRotator(MessageArr[i]);
 if ((*{Declare_PropertyPtr})[i] != NewVector)
 {
   (*{Declare_PropertyPtr})[i] = NewVector;
-  if (!bPropChanged)
+  if (!b{Declare_PropertyName}Changed)
   {
-    bPropChanged = true;
+    b{Declare_PropertyName}Changed = true;
   }
 }
 )EOF";

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator/StringPropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator/StringPropertyDecorator.h
@@ -18,9 +18,9 @@ FString NewString = UTF8_TO_TCHAR(MessageArr[i].c_str());
 if ((*{Declare_PropertyPtr})[i] != NewString)
 {
   (*{Declare_PropertyPtr})[i] = NewString;
-  if (!bPropChanged)
+  if (!b{Declare_PropertyName}Changed)
   {
-    bPropChanged = true;
+    b{Declare_PropertyName}Changed = true;
   }
 }
 )EOF";
@@ -41,5 +41,5 @@ public:
 
 	virtual FString GetCode_SetDeltaStateArrayInner(const FString& PropertyPointer, const FString& FullStateName, const FString& DeltaStateName, bool ConditionFullStateIsNull) override;
 
-	virtual FString GetCode_SetPropertyValueArrayInner(const FString& PropertyPointer, const FString& NewStateName) override;
+	virtual FString GetCode_SetPropertyValueArrayInner(const FString& ArrayPropertyName, const FString& PropertyPointer, const FString& NewStateName) override;
 };

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator/StructPropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator/StructPropertyDecorator.h
@@ -77,9 +77,9 @@ const static TCHAR* StructPropDeco_SetDeltaStateArrayInnerTemp =
 
 const static TCHAR* StructPropDeco_SetPropertyValueArrayInnerTemp =
 	LR"EOF(
-if ({Declare_PropPtrGroupStructName}::SetPropertyValue(&(*{Declare_PropertyPtr})[i], &MessageArr[i], {Code_GetWorldRef}) && !bPropChanged)
+if ({Declare_PropPtrGroupStructName}::SetPropertyValue(&(*{Declare_PropertyPtr})[i], &MessageArr[i], {Code_GetWorldRef}) && !b{Declare_PropertyName}Changed)
 {
-  bPropChanged = true;
+  b{Declare_PropertyName}Changed = true;
 }
 )EOF";
 
@@ -118,7 +118,7 @@ public:
 
 	virtual FString GetCode_OnStateChangeByMemOffset(const FString& ContainerName, const FString& NewStateName) override;
 
-	virtual FString GetCode_SetPropertyValueArrayInner(const FString& TargetInstance, const FString& NewStateName) override;
+	virtual FString GetCode_SetPropertyValueArrayInner(const FString& ArrayPropertyName, const FString& TargetInstance, const FString& NewStateName) override;
 
 	FString GetDeclaration_PropPtrGroupStruct();
 

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator/TextPropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator/TextPropertyDecorator.h
@@ -49,9 +49,9 @@ FText NewText = FText::FromString(UTF8_TO_TCHAR(MessageArr[i].c_str()));
 if (!(*{Declare_PropertyPtr})[i].EqualTo(NewText))
 {
   (*{Declare_PropertyPtr})[i] = NewText;
-  if (!bPropChanged)
+  if (!b{Declare_PropertyName}Changed)
   {
-    bPropChanged = true;
+    b{Declare_PropertyName}Changed = true;
   }
 }
 )EOF";
@@ -77,5 +77,5 @@ public:
 	virtual FString GetCode_SetDeltaStateArrayInner(const FString& PropertyPointer, const FString& FullStateName, const FString& DeltaStateName, bool ConditionFullStateIsNull) override;
 
 	virtual FString GetCode_OnStateChangeByMemOffset(const FString& ContainerName, const FString& NewStateName) override;
-	virtual FString GetCode_SetPropertyValueArrayInner(const FString& PropertyPointer, const FString& NewStateName) override;
+	virtual FString GetCode_SetPropertyValueArrayInner(const FString& ArrayPropertyName, const FString& PropertyPointer, const FString& NewStateName) override;
 };

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator/UnrealObjectPropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator/UnrealObjectPropertyDecorator.h
@@ -18,9 +18,9 @@ UObject* NewObjRef = ChanneldUtils::GetObjectByRef(&MessageArr[i], {Code_GetWorl
 if ((*{Declare_PropertyPtr})[i] != NewObjRef)
 {
   (*{Declare_PropertyPtr})[i] = NewObjRef;
-  if (!bPropChanged)
+  if (!b{Declare_PropertyName}Changed)
   {
-    bPropChanged = true;
+    b{Declare_PropertyName}Changed = true;
   }
 }
 )EOF";
@@ -51,7 +51,7 @@ public:
 	virtual FString GetCode_SetPropertyValueTo(const FString& TargetInstance, const FString& NewStateName, const FString& AfterSetValueCode) override;
 	virtual FString GetCode_SetDeltaStateArrayInner(const FString& PropertyPointer, const FString& FullStateName, const FString& DeltaStateName, bool ConditionFullStateIsNull) override;
 
-	virtual FString GetCode_SetPropertyValueArrayInner(const FString& PropertyPointer, const FString& NewStateName) override;
+	virtual FString GetCode_SetPropertyValueArrayInner(const FString& ArrayPropertyName, const FString& PropertyPointer, const FString& NewStateName) override;
 
 	virtual TArray<FString> GetAdditionalIncludes() override;
 

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator/VectorPropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator/VectorPropertyDecorator.h
@@ -48,9 +48,9 @@ const static TCHAR* VectorPropDeco_OnChangeStateArrayInnerTemp =
 if (ChanneldUtils::CheckDifference((*{Declare_PropertyPtr})[i], &MessageArr[i]))
 {
   ChanneldUtils::{FunctionName_SetXXXFromPB}((*{Declare_PropertyPtr})[i], MessageArr[i]);
-  if (!bPropChanged)
+  if (!b{Declare_PropertyName}Changed)
   {
-    bPropChanged = true;
+    b{Declare_PropertyName}Changed = true;
   }
 }
 )EOF";
@@ -88,7 +88,7 @@ public:
 
 	virtual FString GetCode_OnStateChangeByMemOffset(const FString& ContainerName, const FString& NewStateName) override;
 
-	virtual FString GetCode_SetPropertyValueArrayInner(const FString& PropertyPointer, const FString& NewStateName) override;
+	virtual FString GetCode_SetPropertyValueArrayInner(const FString& ArrayPropertyName, const FString& PropertyPointer, const FString& NewStateName) override;
 
 	virtual TArray<FString> GetAdditionalIncludes() override;
 };


### PR DESCRIPTION
- Moved the declaration of `bPropChanged` and `OldValue` to the `OnStateChanged` function scope;
- Updated the built-in replicators as well;
- Removed "bStateChanged=true" statement in generated `OnStateChanged` function;
