### PR TITLE
Modify property decorator to determine mem offset at runtime

### DIFF
--- a/Source/ReplicatorGenerator/Private/PropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator.cpp
@@ -182,6 +182,7 @@ FString FPropertyDecorator::GetCode_AssignPropPointer(const FString& Container, 
 	FormatArgs.Add(TEXT("Ref_ContainerAddr"), Container);
 	FormatArgs.Add(TEXT("Declare_PropertyCPPType"), GetCPPType());
 	FormatArgs.Add(TEXT("Num_PropMemOffset"), MemOffset);
+    FormatArgs.Add(TEXT("Declare_PropertyName"), GetPropertyName());
 
 	return FString::Format(PropDecorator_AssignPropPtrTemp, FormatArgs);
 }

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator.cpp
@@ -170,6 +170,11 @@ FString FPropertyDecorator::GetCode_AssignPropPointer(const FString& Container, 
 	return GetCode_AssignPropPointer(Container, AssignTo, GetMemOffset());
 }
 
+FString FPropertyDecorator::GetCode_AssignPropPointerForGlobalStruct(const FString& Container, const FString& AssignTo)
+{
+    return GetCode_AssignPropPointerForGlobalStruct(Container, AssignTo, GetMemOffset());
+}
+
 FString FPropertyDecorator::GetCode_AssignPropPointer(const FString& Container, const FString& AssignTo, int32 MemOffset)
 {
 	FStringFormatNamedArguments FormatArgs;
@@ -179,6 +184,18 @@ FString FPropertyDecorator::GetCode_AssignPropPointer(const FString& Container, 
 	FormatArgs.Add(TEXT("Num_PropMemOffset"), MemOffset);
 
 	return FString::Format(PropDecorator_AssignPropPtrTemp, FormatArgs);
+}
+
+FString FPropertyDecorator::GetCode_AssignPropPointerForGlobalStruct(const FString& Container, const FString& AssignTo, int32 MemOffset)
+{
+    FStringFormatNamedArguments FormatArgs;
+    FormatArgs.Add(TEXT("Ref_AssignTo"), AssignTo);
+    FormatArgs.Add(TEXT("Ref_ContainerAddr"), Container);
+    FormatArgs.Add(TEXT("Declare_PropertyCPPType"), GetCPPType());
+    FormatArgs.Add(TEXT("Num_PropMemOffset"), MemOffset);
+    FormatArgs.Add(TEXT("Declare_PropertyName"), GetPropertyName());
+
+    return FString::Format(PropDecorator_AssignPropPtrTemp, FormatArgs);
 }
 
 FString FPropertyDecorator::GetCode_GetProtoFieldValueFrom(const FString& StateName)
@@ -220,7 +237,7 @@ FString FPropertyDecorator::GetCode_SetDeltaStateByMemOffset(const FString& Cont
 	FStringFormatNamedArguments FormatArgs;
 	FormatArgs.Add(
 		TEXT("Code_AssignPropPointers"),
-		GetCode_AssignPropPointer(
+		GetCode_AssignPropPointerForGlobalStruct(
 			ContainerName,
 			FString::Printf(TEXT("%s* PropAddr"), *GetCPPType())
 		)
@@ -280,7 +297,7 @@ FString FPropertyDecorator::GetCode_OnStateChangeByMemOffset(const FString& Cont
 	FStringFormatNamedArguments FormatArgs;
 	FormatArgs.Add(
 		TEXT("Code_AssignPropPointers"),
-		GetCode_AssignPropPointer(
+		GetCode_AssignPropPointerForGlobalStruct(
 			ContainerName,
 			FString::Printf(TEXT("%s* PropAddr"), *GetCPPType())
 		)

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator.cpp
@@ -170,11 +170,6 @@ FString FPropertyDecorator::GetCode_AssignPropPointer(const FString& Container, 
 	return GetCode_AssignPropPointer(Container, AssignTo, GetMemOffset());
 }
 
-FString FPropertyDecorator::GetCode_AssignPropPointerForGlobalStruct(const FString& Container, const FString& AssignTo)
-{
-    return GetCode_AssignPropPointerForGlobalStruct(Container, AssignTo, GetMemOffset());
-}
-
 FString FPropertyDecorator::GetCode_AssignPropPointer(const FString& Container, const FString& AssignTo, int32 MemOffset)
 {
 	FStringFormatNamedArguments FormatArgs;
@@ -185,18 +180,6 @@ FString FPropertyDecorator::GetCode_AssignPropPointer(const FString& Container, 
     FormatArgs.Add(TEXT("Declare_PropertyName"), GetPropertyName());
 
 	return FString::Format(PropDecorator_AssignPropPtrTemp, FormatArgs);
-}
-
-FString FPropertyDecorator::GetCode_AssignPropPointerForGlobalStruct(const FString& Container, const FString& AssignTo, int32 MemOffset)
-{
-    FStringFormatNamedArguments FormatArgs;
-    FormatArgs.Add(TEXT("Ref_AssignTo"), AssignTo);
-    FormatArgs.Add(TEXT("Ref_ContainerAddr"), Container);
-    FormatArgs.Add(TEXT("Declare_PropertyCPPType"), GetCPPType());
-    FormatArgs.Add(TEXT("Num_PropMemOffset"), MemOffset);
-    FormatArgs.Add(TEXT("Declare_PropertyName"), GetPropertyName());
-
-    return FString::Format(PropDecorator_AssignPropPtrTemp, FormatArgs);
 }
 
 FString FPropertyDecorator::GetCode_GetProtoFieldValueFrom(const FString& StateName)
@@ -238,7 +221,7 @@ FString FPropertyDecorator::GetCode_SetDeltaStateByMemOffset(const FString& Cont
 	FStringFormatNamedArguments FormatArgs;
 	FormatArgs.Add(
 		TEXT("Code_AssignPropPointers"),
-		GetCode_AssignPropPointerForGlobalStruct(
+		GetCode_AssignPropPointer(
 			ContainerName,
 			FString::Printf(TEXT("%s* PropAddr"), *GetCPPType())
 		)
@@ -298,7 +281,7 @@ FString FPropertyDecorator::GetCode_OnStateChangeByMemOffset(const FString& Cont
 	FStringFormatNamedArguments FormatArgs;
 	FormatArgs.Add(
 		TEXT("Code_AssignPropPointers"),
-		GetCode_AssignPropPointerForGlobalStruct(
+		GetCode_AssignPropPointer(
 			ContainerName,
 			FString::Printf(TEXT("%s* PropAddr"), *GetCPPType())
 		)

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/StructPropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/StructPropertyDecorator.cpp
@@ -71,6 +71,7 @@ FString FStructPropertyDecorator::GetCode_AssignPropPointer(const FString& Conta
 	FormatArgs.Add(TEXT("Declare_PropertyCPPType"), GetCPPType());
 	FormatArgs.Add(TEXT("Num_PropMemOffset"), MemOffset);
 	FormatArgs.Add(TEXT("Declare_PropPtrGroupStructName"), GetDeclaration_PropPtrGroupStructName());
+    FormatArgs.Add(TEXT("Declare_PropertyName"), GetPropertyName());
 
 	return FString::Format(StructPropDeco_AssignPropPtrTemp, FormatArgs);
 }
@@ -84,7 +85,6 @@ FString FStructPropertyDecorator::GetCode_AssignPropPointerForGlobalStruct(const
     FormatArgs.Add(TEXT("Num_PropMemOffset"), MemOffset);
     FormatArgs.Add(TEXT("Declare_PropPtrGroupStructName"), GetDeclaration_PropPtrGroupStructName());
     FormatArgs.Add(TEXT("Declare_PropertyName"), GetPropertyName());
-
 
     return FString::Format(StructPropDeco_AssignPropPtrForGlobalStructTemp, FormatArgs);
 }

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/StructPropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/StructPropertyDecorator.cpp
@@ -75,6 +75,20 @@ FString FStructPropertyDecorator::GetCode_AssignPropPointer(const FString& Conta
 	return FString::Format(StructPropDeco_AssignPropPtrTemp, FormatArgs);
 }
 
+FString FStructPropertyDecorator::GetCode_AssignPropPointerForGlobalStruct(const FString& Container, const FString& AssignTo, int32 MemOffset)
+{
+    FStringFormatNamedArguments FormatArgs;
+    FormatArgs.Add(TEXT("Ref_AssignTo"), AssignTo);
+    FormatArgs.Add(TEXT("Ref_ContainerAddr"), Container);
+    FormatArgs.Add(TEXT("Declare_PropertyCPPType"), GetCPPType());
+    FormatArgs.Add(TEXT("Num_PropMemOffset"), MemOffset);
+    FormatArgs.Add(TEXT("Declare_PropPtrGroupStructName"), GetDeclaration_PropPtrGroupStructName());
+    FormatArgs.Add(TEXT("Declare_PropertyName"), GetPropertyName());
+
+
+    return FString::Format(StructPropDeco_AssignPropPtrForGlobalStructTemp, FormatArgs);
+}
+
 TArray<FString> FStructPropertyDecorator::GetAdditionalIncludes()
 {
 	TSet<FString> IncludeFileSet{GenManager_GlobalStructHeaderFile, GenManager_GlobalStructProtoHeaderFile};

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/StructPropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/StructPropertyDecorator.cpp
@@ -76,19 +76,6 @@ FString FStructPropertyDecorator::GetCode_AssignPropPointer(const FString& Conta
 	return FString::Format(StructPropDeco_AssignPropPtrTemp, FormatArgs);
 }
 
-FString FStructPropertyDecorator::GetCode_AssignPropPointerForGlobalStruct(const FString& Container, const FString& AssignTo, int32 MemOffset)
-{
-    FStringFormatNamedArguments FormatArgs;
-    FormatArgs.Add(TEXT("Ref_AssignTo"), AssignTo);
-    FormatArgs.Add(TEXT("Ref_ContainerAddr"), Container);
-    FormatArgs.Add(TEXT("Declare_PropertyCPPType"), GetCPPType());
-    FormatArgs.Add(TEXT("Num_PropMemOffset"), MemOffset);
-    FormatArgs.Add(TEXT("Declare_PropPtrGroupStructName"), GetDeclaration_PropPtrGroupStructName());
-    FormatArgs.Add(TEXT("Declare_PropertyName"), GetPropertyName());
-
-    return FString::Format(StructPropDeco_AssignPropPtrForGlobalStructTemp, FormatArgs);
-}
-
 TArray<FString> FStructPropertyDecorator::GetAdditionalIncludes()
 {
 	TSet<FString> IncludeFileSet{GenManager_GlobalStructHeaderFile, GenManager_GlobalStructProtoHeaderFile};

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator.h
@@ -4,7 +4,19 @@
 
 
 static const TCHAR* PropDecorator_AssignPropPtrTemp =
-	LR"EOF({Ref_AssignTo} = ({Declare_PropertyCPPType}*)((uint8*){Ref_ContainerAddr} + {Num_PropMemOffset}))EOF";
+		LR"EOF(
+FString PropertyName = TEXT("{Declare_PropertyName}");
+FProperty* Property = ActorClass->FindPropertyByName(FName(*PropertyName));
+if (Property) {
+	{Ref_AssignTo} = ({Declare_PropertyCPPType}*)((uint8*){Ref_ContainerAddr} + Property->GetOffset_ForInternal());
+}
+else {
+	{Ref_AssignTo} = ({Declare_PropertyCPPType}*)((uint8*){Ref_ContainerAddr} + {Num_PropMemOffset});
+}
+)EOF";
+
+static const TCHAR* PropDecorator_AssignPropPtrForGlobalStructTemp =
+LR"EOF({Ref_AssignTo} = ({Declare_PropertyCPPType}*)((uint8*){Ref_ContainerAddr} + {Num_PropMemOffset}))EOF";
 
 const static TCHAR* PropDecorator_SetDeltaStateTemplate =
 	LR"EOF(
@@ -216,6 +228,8 @@ public:
 
 	virtual FString GetCode_AssignPropPointer(const FString& Container, const FString& AssignTo);
 	virtual FString GetCode_AssignPropPointer(const FString& Container, const FString& AssignTo, int32 MemOffset);
+    virtual FString GetCode_AssignPropPointerForGlobalStruct(const FString& Container, const FString& AssignTo);
+    virtual FString GetCode_AssignPropPointerForGlobalStruct(const FString& Container, const FString& AssignTo, int32 MemOffset);
 
 	/**
 	 * Code that get field value from protobuf message

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator.h
@@ -6,9 +6,10 @@
 const static TCHAR* PropDecorator_AssignPropPtrTemp =
 		LR"EOF(
 FString PropertyName = TEXT("{Declare_PropertyName}");
-if (PropPointerMemOffsetCache.Contains(PropertyName))
+int32* OffsetPtr = PropPointerMemOffsetCache.Find(PropertyName);
+if (OffsetPtr != nullptr)
 {
-    {Ref_AssignTo} = ({Declare_PropertyCPPType}*)((uint8*){Ref_ContainerAddr} + PropPointerMemOffsetCache[PropertyName]);
+    {Ref_AssignTo} = ({Declare_PropertyCPPType}*)((uint8*){Ref_ContainerAddr} + *OffsetPtr);
 }
 else
 {
@@ -237,7 +238,6 @@ public:
 
 	virtual FString GetCode_AssignPropPointer(const FString& Container, const FString& AssignTo);
 	virtual FString GetCode_AssignPropPointer(const FString& Container, const FString& AssignTo, int32 MemOffset);
-    static TMap<FString, int32> PropPointerMemOffsetCache;
 
 	/**
 	 * Code that get field value from protobuf message

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator/StructPropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator/StructPropertyDecorator.h
@@ -70,6 +70,11 @@ else {
 }
 )EOF";
 
+const static TCHAR* StructPropDeco_AssignPropPtrForGlobalStructTemp =
+    LR"EOF(
+void* PropertyAddr = (uint8*){Ref_ContainerAddr} + {Num_PropMemOffset};
+{Ref_AssignTo} = {Declare_PropPtrGroupStructName}(PropertyAddr))EOF";
+
 const static TCHAR* StructPropDeco_SetDeltaStateArrayInnerTemp =
 	LR"EOF(
 {

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator/StructPropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator/StructPropertyDecorator.h
@@ -60,9 +60,10 @@ const static TCHAR* StructPropDeco_AssignPropPtrTemp =
     LR"EOF(
 FString PropertyName = TEXT("{Declare_PropertyName}");
 void* PropertyAddr = (uint8*){Ref_ContainerAddr};
-if (StructPropPointerMemOffsetCache.Contains(PropertyName))
+int32* OffsetPtr = PropPointerMemOffsetCache.Find(PropertyName);
+if (OffsetPtr != nullptr)
 {    
-    {Ref_AssignTo} = ({Declare_PropPtrGroupStructName})(PropertyAddr + StructPropPointerMemOffsetCache[PropertyName]);
+    {Ref_AssignTo} = ({Declare_PropPtrGroupStructName})(PropertyAddr + *OffsetPtr);
 }
 else
 {
@@ -70,7 +71,7 @@ else
     if (Property)
     {
         int32 Offset = Property->GetOffset_ForInternal();
-        StructPropPointerMemOffsetCache.Emplace(PropertyName, Offset);
+        PropPointerMemOffsetCache.Emplace(PropertyName, Offset);
         {Ref_AssignTo} = ({Declare_PropPtrGroupStructName})(PropertyAddr + Offset);
     }
     else
@@ -122,7 +123,6 @@ public:
 	virtual FString GetDeclaration_PropertyPtr() override;
 	
 	virtual FString GetCode_AssignPropPointer(const FString& Container, const FString& AssignTo, int32 MemOffset) override;
-    static TMap<FString, int32> StructPropPointerMemOffsetCache;
 	
 	virtual TArray<FString> GetAdditionalIncludes() override;
 	

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator/StructPropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator/StructPropertyDecorator.h
@@ -57,9 +57,18 @@ struct {Declare_PropCompilableStructName}
 )EOF";
 
 const static TCHAR* StructPropDeco_AssignPropPtrTemp =
-	LR"EOF(
-void* PropertyAddr = (uint8*){Ref_ContainerAddr} + {Num_PropMemOffset};
-{Ref_AssignTo} = {Declare_PropPtrGroupStructName}(PropertyAddr))EOF";
+    LR"EOF(
+FString PropertyName = TEXT("{Declare_PropertyName}");
+FProperty* Property = ActorClass->FindPropertyByName(FName(*PropertyName));
+if (Property) {
+	void* PropertyAddr = (uint8*){Ref_ContainerAddr} + Property->GetOffset_ForInternal();
+	{Ref_AssignTo} = {Declare_PropPtrGroupStructName}(PropertyAddr);
+}
+else {
+	void* PropertyAddr = (uint8*){Ref_ContainerAddr} + {Num_PropMemOffset};
+	{Ref_AssignTo} = {Declare_PropPtrGroupStructName}(PropertyAddr);
+}
+)EOF";
 
 const static TCHAR* StructPropDeco_SetDeltaStateArrayInnerTemp =
 	LR"EOF(
@@ -102,6 +111,7 @@ public:
 	virtual FString GetDeclaration_PropertyPtr() override;
 	
 	virtual FString GetCode_AssignPropPointer(const FString& Container, const FString& AssignTo, int32 MemOffset) override;
+    virtual FString GetCode_AssignPropPointerForGlobalStruct(const FString& Container, const FString& AssignTo, int32 MemOffset) override;
 	
 	virtual TArray<FString> GetAdditionalIncludes() override;
 	

--- a/Source/ReplicatorGenerator/Public/ReplicatorTemplate/BlueprintReplicatorTemplate.h
+++ b/Source/ReplicatorGenerator/Public/ReplicatorTemplate/BlueprintReplicatorTemplate.h
@@ -28,6 +28,7 @@ public:
 
 protected:
   TWeakObjectPtr<{Declare_TargetBaseClassName}> {Ref_TargetInstanceRef};
+  static TMap<FString, int32> PropPointerMemOffsetCache; 
 
   // [Server+Client] The accumulated channel data of the target object
   {Declare_ProtoNamespace}::{Declare_ProtoStateMsgName}* FullState;

--- a/Source/ReplicatorGenerator/Public/ReplicatorTemplate/BlueprintReplicatorTemplate.h
+++ b/Source/ReplicatorGenerator/Public/ReplicatorTemplate/BlueprintReplicatorTemplate.h
@@ -52,6 +52,11 @@ static const TCHAR* CodeGen_BP_ConstructorImplTemplate =
 
   FullState = new {Declare_ProtoNamespace}::{Declare_ProtoStateMsgName};
   DeltaState = new {Declare_ProtoNamespace}::{Declare_ProtoStateMsgName};
+  
+  UClass* ActorClass = {Declare_TargetClassName}::StaticClass();
+  if (!ActorClass) {
+    return;
+  }
 
 {Code_AssignPropertyPointers}
 }

--- a/Source/ReplicatorGenerator/Public/ReplicatorTemplate/CppReplicatorTemplate.h
+++ b/Source/ReplicatorGenerator/Public/ReplicatorTemplate/CppReplicatorTemplate.h
@@ -30,6 +30,7 @@ public:
 
 protected:
   TWeakObjectPtr<{Declare_TargetClassName}> {Ref_TargetInstanceRef};
+  static TMap<FString, int32> PropPointerMemOffsetCache;  
 
   // [Server+Client] The accumulated channel data of the target object
   {Declare_ProtoNamespace}::{Declare_ProtoStateMsgName}* FullState;

--- a/Source/ReplicatorGenerator/Public/ReplicatorTemplate/CppReplicatorTemplate.h
+++ b/Source/ReplicatorGenerator/Public/ReplicatorTemplate/CppReplicatorTemplate.h
@@ -60,6 +60,11 @@ static const TCHAR* CodeGen_CPP_ConstructorImplTemplate =
   FullState = new {Declare_ProtoNamespace}::{Declare_ProtoStateMsgName};
   DeltaState = new {Declare_ProtoNamespace}::{Declare_ProtoStateMsgName};
 
+  UClass* ActorClass = {Declare_TargetClassName}::StaticClass();
+  if (!ActorClass) {
+    return;
+  }
+
 {Code_AssignPropertyPointers}
 }
 )EOF";


### PR DESCRIPTION
This is to prevent crashing on builds across different machines with different memory architectures.

When attempting to deploy DS on a separate linux machine, it will crash will client tries to login. This is due to inconsistency
in memory offsets between Windows & Linux for properties, so when memory offset is generated at compile time, it will be based on the host build machine, hence it will be incompatible if we try to deploy the build on a machine with different architecture. (Value of Num_PropMemOffset different from Property->GetOffset_ForInternal() on Linux)

For example, when debug print statements were added inside the generated code, Property->GetOffsetForInternal() produced different values across different machines.

![image](https://github.com/metaworking/channeld-ue-plugin/assets/63161432/9d17ec2b-3c1c-444a-b000-e2c8273ffd27)

(The white background log is on windows with an offset of 2040, the bottom log is on linux with an offset of 1672, both for the same property)

However, it comes at a runtime cost, so if we know that client/server will be deployed on machines with the same memory architecture, we can use PropPtrForGlobalStruct instead, which is the original implementation.

