### PR TITLE
Fix issues regarding the property memory offset

### DIFF
--- a/Source/ReplicatorGenerator/Private/PropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator.cpp
@@ -165,21 +165,28 @@ FString FPropertyDecorator::GetDeclaration_PropertyPtr()
 	return FString::Printf(TEXT("%s* %s"), *this->GetCPPType(), *this->GetPointerName());
 }
 
-FString FPropertyDecorator::GetCode_AssignPropPointer(const FString& Container, const FString& AssignTo)
-{
-	return GetCode_AssignPropPointer(Container, AssignTo, GetMemOffset());
-}
-
-FString FPropertyDecorator::GetCode_AssignPropPointer(const FString& Container, const FString& AssignTo, int32 MemOffset)
+FString FPropertyDecorator::GetCode_AssignPropPointerStatic(const FString& Container, const FString& AssignTo)
 {
 	FStringFormatNamedArguments FormatArgs;
 	FormatArgs.Add(TEXT("Ref_AssignTo"), AssignTo);
 	FormatArgs.Add(TEXT("Ref_ContainerAddr"), Container);
 	FormatArgs.Add(TEXT("Declare_PropertyCPPType"), GetCPPType());
-	FormatArgs.Add(TEXT("Num_PropMemOffset"), MemOffset);
+	FormatArgs.Add(TEXT("Num_PropMemOffset"), GetMemOffset());
+	FormatArgs.Add(TEXT("Declare_PropertyName"), GetPropertyName());
+
+	return FString::Format(PropDecorator_AssignPropPtrStatic, FormatArgs);
+}
+
+FString FPropertyDecorator::GetCode_AssignPropPointerDynamic(const FString& Container, const FString& AssignTo)
+{
+	FStringFormatNamedArguments FormatArgs;
+	FormatArgs.Add(TEXT("Ref_AssignTo"), AssignTo);
+	FormatArgs.Add(TEXT("Ref_ContainerAddr"), Container);
+	FormatArgs.Add(TEXT("Declare_PropertyCPPType"), GetCPPType());
+	FormatArgs.Add(TEXT("Num_PropMemOffset"), GetMemOffset());
     FormatArgs.Add(TEXT("Declare_PropertyName"), GetPropertyName());
 
-	return FString::Format(PropDecorator_AssignPropPtrTemp, FormatArgs);
+	return FString::Format(PropDecorator_AssignPropPtrDynamic, FormatArgs);
 }
 
 FString FPropertyDecorator::GetCode_GetProtoFieldValueFrom(const FString& StateName)
@@ -221,7 +228,7 @@ FString FPropertyDecorator::GetCode_SetDeltaStateByMemOffset(const FString& Cont
 	FStringFormatNamedArguments FormatArgs;
 	FormatArgs.Add(
 		TEXT("Code_AssignPropPointers"),
-		GetCode_AssignPropPointer(
+		GetCode_AssignPropPointerStatic(
 			ContainerName,
 			FString::Printf(TEXT("%s* PropAddr"), *GetCPPType())
 		)
@@ -281,7 +288,7 @@ FString FPropertyDecorator::GetCode_OnStateChangeByMemOffset(const FString& Cont
 	FStringFormatNamedArguments FormatArgs;
 	FormatArgs.Add(
 		TEXT("Code_AssignPropPointers"),
-		GetCode_AssignPropPointer(
+		GetCode_AssignPropPointerStatic(
 			ContainerName,
 			FString::Printf(TEXT("%s* PropAddr"), *GetCPPType())
 		)

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator.cpp
@@ -182,6 +182,7 @@ FString FPropertyDecorator::GetCode_AssignPropPointer(const FString& Container, 
 	FormatArgs.Add(TEXT("Ref_ContainerAddr"), Container);
 	FormatArgs.Add(TEXT("Declare_PropertyCPPType"), GetCPPType());
 	FormatArgs.Add(TEXT("Num_PropMemOffset"), MemOffset);
+    FormatArgs.Add(TEXT("Declare_PropertyName"), GetPropertyName());
 
 	return FString::Format(PropDecorator_AssignPropPtrTemp, FormatArgs);
 }

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator.cpp
@@ -170,6 +170,11 @@ FString FPropertyDecorator::GetCode_AssignPropPointer(const FString& Container, 
 	return GetCode_AssignPropPointer(Container, AssignTo, GetMemOffset());
 }
 
+FString FPropertyDecorator::GetCode_AssignPropPointerForGlobalStruct(const FString& Container, const FString& AssignTo)
+{
+    return GetCode_AssignPropPointerForGlobalStruct(Container, AssignTo, GetMemOffset());
+}
+
 FString FPropertyDecorator::GetCode_AssignPropPointer(const FString& Container, const FString& AssignTo, int32 MemOffset)
 {
 	FStringFormatNamedArguments FormatArgs;
@@ -179,6 +184,18 @@ FString FPropertyDecorator::GetCode_AssignPropPointer(const FString& Container, 
 	FormatArgs.Add(TEXT("Num_PropMemOffset"), MemOffset);
 
 	return FString::Format(PropDecorator_AssignPropPtrTemp, FormatArgs);
+}
+
+FString FPropertyDecorator::GetCode_AssignPropPointerForGlobalStruct(const FString& Container, const FString& AssignTo, int32 MemOffset)
+{
+    FStringFormatNamedArguments FormatArgs;
+    FormatArgs.Add(TEXT("Ref_AssignTo"), AssignTo);
+    FormatArgs.Add(TEXT("Ref_ContainerAddr"), Container);
+    FormatArgs.Add(TEXT("Declare_PropertyCPPType"), GetCPPType());
+    FormatArgs.Add(TEXT("Num_PropMemOffset"), MemOffset);
+    FormatArgs.Add(TEXT("Declare_PropertyName"), GetPropertyName());
+
+    return FString::Format(PropDecorator_AssignPropPtrTemp, FormatArgs);
 }
 
 FString FPropertyDecorator::GetCode_GetProtoFieldValueFrom(const FString& StateName)
@@ -220,7 +237,7 @@ FString FPropertyDecorator::GetCode_SetDeltaStateByMemOffset(const FString& Cont
 	FStringFormatNamedArguments FormatArgs;
 	FormatArgs.Add(
 		TEXT("Code_AssignPropPointers"),
-		GetCode_AssignPropPointer(
+		GetCode_AssignPropPointerForGlobalStruct(
 			ContainerName,
 			FString::Printf(TEXT("%s* PropAddr"), *GetCPPType())
 		)
@@ -280,7 +297,7 @@ FString FPropertyDecorator::GetCode_OnStateChangeByMemOffset(const FString& Cont
 	FStringFormatNamedArguments FormatArgs;
 	FormatArgs.Add(
 		TEXT("Code_AssignPropPointers"),
-		GetCode_AssignPropPointer(
+		GetCode_AssignPropPointerForGlobalStruct(
 			ContainerName,
 			FString::Printf(TEXT("%s* PropAddr"), *GetCPPType())
 		)

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator.cpp
@@ -170,11 +170,6 @@ FString FPropertyDecorator::GetCode_AssignPropPointer(const FString& Container, 
 	return GetCode_AssignPropPointer(Container, AssignTo, GetMemOffset());
 }
 
-FString FPropertyDecorator::GetCode_AssignPropPointerForGlobalStruct(const FString& Container, const FString& AssignTo)
-{
-    return GetCode_AssignPropPointerForGlobalStruct(Container, AssignTo, GetMemOffset());
-}
-
 FString FPropertyDecorator::GetCode_AssignPropPointer(const FString& Container, const FString& AssignTo, int32 MemOffset)
 {
 	FStringFormatNamedArguments FormatArgs;
@@ -185,18 +180,6 @@ FString FPropertyDecorator::GetCode_AssignPropPointer(const FString& Container, 
     FormatArgs.Add(TEXT("Declare_PropertyName"), GetPropertyName());
 
 	return FString::Format(PropDecorator_AssignPropPtrTemp, FormatArgs);
-}
-
-FString FPropertyDecorator::GetCode_AssignPropPointerForGlobalStruct(const FString& Container, const FString& AssignTo, int32 MemOffset)
-{
-    FStringFormatNamedArguments FormatArgs;
-    FormatArgs.Add(TEXT("Ref_AssignTo"), AssignTo);
-    FormatArgs.Add(TEXT("Ref_ContainerAddr"), Container);
-    FormatArgs.Add(TEXT("Declare_PropertyCPPType"), GetCPPType());
-    FormatArgs.Add(TEXT("Num_PropMemOffset"), MemOffset);
-    FormatArgs.Add(TEXT("Declare_PropertyName"), GetPropertyName());
-
-    return FString::Format(PropDecorator_AssignPropPtrTemp, FormatArgs);
 }
 
 FString FPropertyDecorator::GetCode_GetProtoFieldValueFrom(const FString& StateName)
@@ -238,7 +221,7 @@ FString FPropertyDecorator::GetCode_SetDeltaStateByMemOffset(const FString& Cont
 	FStringFormatNamedArguments FormatArgs;
 	FormatArgs.Add(
 		TEXT("Code_AssignPropPointers"),
-		GetCode_AssignPropPointerForGlobalStruct(
+		GetCode_AssignPropPointer(
 			ContainerName,
 			FString::Printf(TEXT("%s* PropAddr"), *GetCPPType())
 		)
@@ -298,7 +281,7 @@ FString FPropertyDecorator::GetCode_OnStateChangeByMemOffset(const FString& Cont
 	FStringFormatNamedArguments FormatArgs;
 	FormatArgs.Add(
 		TEXT("Code_AssignPropPointers"),
-		GetCode_AssignPropPointerForGlobalStruct(
+		GetCode_AssignPropPointer(
 			ContainerName,
 			FString::Printf(TEXT("%s* PropAddr"), *GetCPPType())
 		)

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/ArrayPropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/ArrayPropertyDecorator.cpp
@@ -73,7 +73,7 @@ FString FArrayPropertyDecorator::GetCode_SetDeltaStateByMemOffset(const FString&
 	FStringFormatNamedArguments FormatArgs;
 	FormatArgs.Add(
 		TEXT("Code_AssignPropPointers"),
-		GetCode_AssignPropPointer(
+		GetCode_AssignPropPointerStatic(
 			ContainerName,
 			FString::Printf(TEXT("%s* PropAddr"), *GetCPPType())
 		)
@@ -132,7 +132,7 @@ FString FArrayPropertyDecorator::GetCode_OnStateChangeByMemOffset(const FString&
 	FStringFormatNamedArguments FormatArgs;
 	FormatArgs.Add(
 		TEXT("Code_AssignPropPointers"),
-		GetCode_AssignPropPointer(
+		GetCode_AssignPropPointerStatic(
 			ContainerName,
 			FString::Printf(TEXT("%s* PropAddr"), *GetCPPType())
 		)

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/StructPropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/StructPropertyDecorator.cpp
@@ -71,6 +71,7 @@ FString FStructPropertyDecorator::GetCode_AssignPropPointer(const FString& Conta
 	FormatArgs.Add(TEXT("Declare_PropertyCPPType"), GetCPPType());
 	FormatArgs.Add(TEXT("Num_PropMemOffset"), MemOffset);
 	FormatArgs.Add(TEXT("Declare_PropPtrGroupStructName"), GetDeclaration_PropPtrGroupStructName());
+    FormatArgs.Add(TEXT("Declare_PropertyName"), GetPropertyName());
 
 	return FString::Format(StructPropDeco_AssignPropPtrTemp, FormatArgs);
 }
@@ -84,7 +85,6 @@ FString FStructPropertyDecorator::GetCode_AssignPropPointerForGlobalStruct(const
     FormatArgs.Add(TEXT("Num_PropMemOffset"), MemOffset);
     FormatArgs.Add(TEXT("Declare_PropPtrGroupStructName"), GetDeclaration_PropPtrGroupStructName());
     FormatArgs.Add(TEXT("Declare_PropertyName"), GetPropertyName());
-
 
     return FString::Format(StructPropDeco_AssignPropPtrForGlobalStructTemp, FormatArgs);
 }

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/StructPropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/StructPropertyDecorator.cpp
@@ -75,6 +75,20 @@ FString FStructPropertyDecorator::GetCode_AssignPropPointer(const FString& Conta
 	return FString::Format(StructPropDeco_AssignPropPtrTemp, FormatArgs);
 }
 
+FString FStructPropertyDecorator::GetCode_AssignPropPointerForGlobalStruct(const FString& Container, const FString& AssignTo, int32 MemOffset)
+{
+    FStringFormatNamedArguments FormatArgs;
+    FormatArgs.Add(TEXT("Ref_AssignTo"), AssignTo);
+    FormatArgs.Add(TEXT("Ref_ContainerAddr"), Container);
+    FormatArgs.Add(TEXT("Declare_PropertyCPPType"), GetCPPType());
+    FormatArgs.Add(TEXT("Num_PropMemOffset"), MemOffset);
+    FormatArgs.Add(TEXT("Declare_PropPtrGroupStructName"), GetDeclaration_PropPtrGroupStructName());
+    FormatArgs.Add(TEXT("Declare_PropertyName"), GetPropertyName());
+
+
+    return FString::Format(StructPropDeco_AssignPropPtrForGlobalStructTemp, FormatArgs);
+}
+
 TArray<FString> FStructPropertyDecorator::GetAdditionalIncludes()
 {
 	TSet<FString> IncludeFileSet{GenManager_GlobalStructHeaderFile, GenManager_GlobalStructProtoHeaderFile};

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/StructPropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/StructPropertyDecorator.cpp
@@ -76,19 +76,6 @@ FString FStructPropertyDecorator::GetCode_AssignPropPointer(const FString& Conta
 	return FString::Format(StructPropDeco_AssignPropPtrTemp, FormatArgs);
 }
 
-FString FStructPropertyDecorator::GetCode_AssignPropPointerForGlobalStruct(const FString& Container, const FString& AssignTo, int32 MemOffset)
-{
-    FStringFormatNamedArguments FormatArgs;
-    FormatArgs.Add(TEXT("Ref_AssignTo"), AssignTo);
-    FormatArgs.Add(TEXT("Ref_ContainerAddr"), Container);
-    FormatArgs.Add(TEXT("Declare_PropertyCPPType"), GetCPPType());
-    FormatArgs.Add(TEXT("Num_PropMemOffset"), MemOffset);
-    FormatArgs.Add(TEXT("Declare_PropPtrGroupStructName"), GetDeclaration_PropPtrGroupStructName());
-    FormatArgs.Add(TEXT("Declare_PropertyName"), GetPropertyName());
-
-    return FString::Format(StructPropDeco_AssignPropPtrForGlobalStructTemp, FormatArgs);
-}
-
 TArray<FString> FStructPropertyDecorator::GetAdditionalIncludes()
 {
 	TSet<FString> IncludeFileSet{GenManager_GlobalStructHeaderFile, GenManager_GlobalStructProtoHeaderFile};

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/StructPropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/StructPropertyDecorator.cpp
@@ -63,17 +63,28 @@ FString FStructPropertyDecorator::GetDeclaration_PropertyPtr()
 	return FString::Printf(TEXT("%s %s"), *GetDeclaration_PropPtrGroupStructName(), *GetPointerName());
 }
 
-FString FStructPropertyDecorator::GetCode_AssignPropPointer(const FString& Container, const FString& AssignTo, int32 MemOffset)
+FString FStructPropertyDecorator::GetCode_AssignPropPointerStatic(const FString& Container, const FString& AssignTo)
+{
+	FStringFormatNamedArguments FormatArgs;
+	FormatArgs.Add(TEXT("Ref_AssignTo"), AssignTo);
+	FormatArgs.Add(TEXT("Ref_ContainerAddr"), Container);
+	FormatArgs.Add(TEXT("Num_PropMemOffset"), GetMemOffset());
+	FormatArgs.Add(TEXT("Declare_PropPtrGroupStructName"), GetDeclaration_PropPtrGroupStructName());
+
+	return FString::Format(StructPropDeco_AssignPropPtrStatic, FormatArgs);
+}
+
+FString FStructPropertyDecorator::GetCode_AssignPropPointerDynamic(const FString& Container, const FString& AssignTo)
 {
 	FStringFormatNamedArguments FormatArgs;
 	FormatArgs.Add(TEXT("Ref_AssignTo"), AssignTo);
 	FormatArgs.Add(TEXT("Ref_ContainerAddr"), Container);
 	FormatArgs.Add(TEXT("Declare_PropertyCPPType"), GetCPPType());
-	FormatArgs.Add(TEXT("Num_PropMemOffset"), MemOffset);
+	FormatArgs.Add(TEXT("Num_PropMemOffset"), GetMemOffset());
 	FormatArgs.Add(TEXT("Declare_PropPtrGroupStructName"), GetDeclaration_PropPtrGroupStructName());
     FormatArgs.Add(TEXT("Declare_PropertyName"), GetPropertyName());
 
-	return FString::Format(StructPropDeco_AssignPropPtrTemp, FormatArgs);
+	return FString::Format(StructPropDeco_AssignPropPtrDynamic, FormatArgs);
 }
 
 TArray<FString> FStructPropertyDecorator::GetAdditionalIncludes()
@@ -180,7 +191,7 @@ FString FStructPropertyDecorator::GetDeclaration_PropPtrGroupStruct()
 		AssignPropertyPointerCodes.Append(
 			FString::Printf(
 				TEXT("{\n%s;\n}\n"),
-				*PropDecorator->GetCode_AssignPropPointer(TEXT("Container"), PropDecorator->GetPointerName())
+				*PropDecorator->GetCode_AssignPropPointerStatic(TEXT("Container"), PropDecorator->GetPointerName())
 			)
 		);
 
@@ -189,7 +200,7 @@ FString FStructPropertyDecorator::GetDeclaration_PropPtrGroupStruct()
 			AssignPropPointersForRPCCodes.Append(
 				FString::Printf(
 					TEXT("{\n%s;\nOutParams = OutParams->NextOutParm;\n}\n"),
-					*PropDecorator->GetCode_AssignPropPointer(TEXT("OutParams->PropAddr"), PropDecorator->GetPointerName(), 0)
+					*PropDecorator->GetCode_AssignPropPointerStatic(TEXT("OutParams->PropAddr"), PropDecorator->GetPointerName())
 				)
 			);
 		}
@@ -198,7 +209,7 @@ FString FStructPropertyDecorator::GetDeclaration_PropPtrGroupStruct()
 			AssignPropPointersForRPCCodes.Append(
 				FString::Printf(
 					TEXT("{\n%s;\n}\n"),
-					*PropDecorator->GetCode_AssignPropPointer(TEXT("Params"), PropDecorator->GetPointerName())
+					*PropDecorator->GetCode_AssignPropPointerStatic(TEXT("Params"), PropDecorator->GetPointerName())
 				)
 			);
 		}

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/TextPropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/TextPropertyDecorator.cpp
@@ -30,7 +30,7 @@ FString FTextPropertyDecorator::GetCode_SetDeltaStateByMemOffset(const FString& 
 	FStringFormatNamedArguments FormatArgs;
 	FormatArgs.Add(
 		TEXT("Code_AssignPropPointers"),
-		GetCode_AssignPropPointer(
+		GetCode_AssignPropPointerStatic(
 			ContainerName,
 			FString::Printf(TEXT("%s* PropAddr"), *GetCPPType())
 		)
@@ -57,7 +57,7 @@ FString FTextPropertyDecorator::GetCode_OnStateChangeByMemOffset(const FString& 
 	FStringFormatNamedArguments FormatArgs;
 	FormatArgs.Add(
 		TEXT("Code_AssignPropPointers"),
-		GetCode_AssignPropPointer(
+		GetCode_AssignPropPointerStatic(
 			ContainerName,
 			FString::Printf(TEXT("%s* PropAddr"), *GetCPPType())
 		)

--- a/Source/ReplicatorGenerator/Private/PropertyDecorator/VectorPropertyDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/PropertyDecorator/VectorPropertyDecorator.cpp
@@ -73,7 +73,7 @@ FString FVectorPropertyDecorator::GetCode_SetDeltaStateByMemOffset(const FString
 	FStringFormatNamedArguments FormatArgs;
 	FormatArgs.Add(
 		TEXT("Code_AssignPropPointers"),
-		GetCode_AssignPropPointer(
+		GetCode_AssignPropPointerStatic(
 			ContainerName,
 			FString::Printf(TEXT("%s* PropAddr"), *GetCPPType())
 		)
@@ -103,7 +103,7 @@ FString FVectorPropertyDecorator::GetCode_OnStateChangeByMemOffset(const FString
 	FStringFormatNamedArguments FormatArgs;
 	FormatArgs.Add(
 		TEXT("Code_AssignPropPointers"),
-		GetCode_AssignPropPointer(
+		GetCode_AssignPropPointerStatic(
 			ContainerName,
 			FString::Printf(TEXT("%s* PropAddr"), *GetCPPType())
 		)

--- a/Source/ReplicatorGenerator/Private/ReplicatedActorDecorator.cpp
+++ b/Source/ReplicatorGenerator/Private/ReplicatedActorDecorator.cpp
@@ -202,7 +202,7 @@ FString FReplicatedActorDecorator::GetCode_AssignPropertyPointers()
 		{
 			Result += FString::Printf(
 				TEXT("{ %s; }\n"),
-				*Property->GetCode_AssignPropPointer(
+				*Property->GetCode_AssignPropPointerDynamic(
 					FString::Printf(TEXT("%s.Get()"), *InstanceRefName),
 					Property->GetPointerName()
 				)

--- a/Source/ReplicatorGenerator/Private/ReplicatorCodeGenerator.cpp
+++ b/Source/ReplicatorGenerator/Private/ReplicatorCodeGenerator.cpp
@@ -298,6 +298,9 @@ bool FReplicatorCodeGenerator::GenerateReplicatorCode(
 	CppCodeBuilder.Append(FString::Printf(TEXT("#include \"%s\"\n"), *GeneratedResult.HeadFileName));
 	CppCodeBuilder.Append(FString::Printf(TEXT("#include \"%s\"\n\n"), *GenManager_TypeDefinitionHeadFile));
 
+	// Define and initialize the static PropPointerMemOffsetCache for the constructor
+	CppCodeBuilder.Append(FString::Printf(TEXT("TMap<FString, int32> %s::PropPointerMemOffsetCache;\n\n"), *ActorDecorator->GetReplicatorClassName()));
+	
 	FormatArgs.Add(
 		TEXT("Code_AssignPropertyPointers"),
 		ActorDecorator->GetCode_AssignPropertyPointers()

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator.h
@@ -4,7 +4,19 @@
 
 
 static const TCHAR* PropDecorator_AssignPropPtrTemp =
-	LR"EOF({Ref_AssignTo} = ({Declare_PropertyCPPType}*)((uint8*){Ref_ContainerAddr} + {Num_PropMemOffset}))EOF";
+		LR"EOF(
+FString PropertyName = TEXT("{Declare_PropertyName}");
+FProperty* Property = ActorClass->FindPropertyByName(FName(*PropertyName));
+if (Property) {
+	{Ref_AssignTo} = ({Declare_PropertyCPPType}*)((uint8*){Ref_ContainerAddr} + Property->GetOffset_ForInternal());
+}
+else {
+	{Ref_AssignTo} = ({Declare_PropertyCPPType}*)((uint8*){Ref_ContainerAddr} + {Num_PropMemOffset});
+}
+)EOF";
+
+static const TCHAR* PropDecorator_AssignPropPtrForGlobalStructTemp =
+LR"EOF({Ref_AssignTo} = ({Declare_PropertyCPPType}*)((uint8*){Ref_ContainerAddr} + {Num_PropMemOffset}))EOF";
 
 const static TCHAR* PropDecorator_SetDeltaStateTemplate =
 	LR"EOF(
@@ -219,6 +231,8 @@ public:
 
 	virtual FString GetCode_AssignPropPointer(const FString& Container, const FString& AssignTo);
 	virtual FString GetCode_AssignPropPointer(const FString& Container, const FString& AssignTo, int32 MemOffset);
+    virtual FString GetCode_AssignPropPointerForGlobalStruct(const FString& Container, const FString& AssignTo);
+    virtual FString GetCode_AssignPropPointerForGlobalStruct(const FString& Container, const FString& AssignTo, int32 MemOffset);
 
 	/**
 	 * Code that get field value from protobuf message

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator.h
@@ -6,9 +6,10 @@
 const static TCHAR* PropDecorator_AssignPropPtrTemp =
 		LR"EOF(
 FString PropertyName = TEXT("{Declare_PropertyName}");
-if (PropPointerMemOffsetCache.Contains(PropertyName))
+int32* OffsetPtr = PropPointerMemOffsetCache.Find(PropertyName);
+if (OffsetPtr != nullptr)
 {
-    {Ref_AssignTo} = ({Declare_PropertyCPPType}*)((uint8*){Ref_ContainerAddr} + PropPointerMemOffsetCache[PropertyName]);
+    {Ref_AssignTo} = ({Declare_PropertyCPPType}*)((uint8*){Ref_ContainerAddr} + *OffsetPtr);
 }
 else
 {
@@ -240,7 +241,6 @@ public:
 
 	virtual FString GetCode_AssignPropPointer(const FString& Container, const FString& AssignTo);
 	virtual FString GetCode_AssignPropPointer(const FString& Container, const FString& AssignTo, int32 MemOffset);
-    static TMap<FString, int32> PropPointerMemOffsetCache;
 
 	/**
 	 * Code that get field value from protobuf message

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator.h
@@ -3,7 +3,11 @@
 #include "IPropertyDecoratorOwner.h"
 
 
-const static TCHAR* PropDecorator_AssignPropPtrTemp =
+const static TCHAR* PropDecorator_AssignPropPtrStatic =
+	LR"EOF(
+{Ref_AssignTo} = ({Declare_PropertyCPPType}*)((uint8*){Ref_ContainerAddr} + {Num_PropMemOffset}))EOF";
+
+const static TCHAR* PropDecorator_AssignPropPtrDynamic =
 		LR"EOF(
 FString PropertyName = TEXT("{Declare_PropertyName}");
 int32* OffsetPtr = PropPointerMemOffsetCache.Find(PropertyName);
@@ -239,8 +243,10 @@ public:
       */
 	virtual FString GetDeclaration_PropertyPtr();
 
-	virtual FString GetCode_AssignPropPointer(const FString& Container, const FString& AssignTo);
-	virtual FString GetCode_AssignPropPointer(const FString& Container, const FString& AssignTo, int32 MemOffset);
+	// Get the property/field pointer via static memory offset. Used for C++ struct and UStruct that follow the Standard Layout.
+	virtual FString GetCode_AssignPropPointerStatic(const FString& Container, const FString& AssignTo);
+	// Get the property pointer via dynamic memory offset. Used for UObject/AActor that memory offset can be different across different platforms.
+	virtual FString GetCode_AssignPropPointerDynamic(const FString& Container, const FString& AssignTo);
 
 	/**
 	 * Code that get field value from protobuf message

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator.h
@@ -3,20 +3,29 @@
 #include "IPropertyDecoratorOwner.h"
 
 
-static const TCHAR* PropDecorator_AssignPropPtrTemp =
+const static TCHAR* PropDecorator_AssignPropPtrTemp =
 		LR"EOF(
 FString PropertyName = TEXT("{Declare_PropertyName}");
-FProperty* Property = ActorClass->FindPropertyByName(FName(*PropertyName));
-if (Property) {
-	{Ref_AssignTo} = ({Declare_PropertyCPPType}*)((uint8*){Ref_ContainerAddr} + Property->GetOffset_ForInternal());
+if (PropPointerMemOffsetCache.Contains(PropertyName))
+{
+    {Ref_AssignTo} = ({Declare_PropertyCPPType}*)((uint8*){Ref_ContainerAddr} + PropPointerMemOffsetCache[PropertyName]);
 }
-else {
-	{Ref_AssignTo} = ({Declare_PropertyCPPType}*)((uint8*){Ref_ContainerAddr} + {Num_PropMemOffset});
+else
+{
+    FProperty* Property = ActorClass->FindPropertyByName(FName(*PropertyName));
+    if (Property)
+    {   
+        int32 Offset = Property->GetOffset_ForInternal();
+        PropPointerMemOffsetCache.Emplace(PropertyName, Offset);
+        {Ref_AssignTo} = ({Declare_PropertyCPPType}*)((uint8*){Ref_ContainerAddr} + Offset);
+    }
+    else
+    {
+        UE_LOG(LogTemp, Error, TEXT("%s Replicator construct, but could not find property(%s) in cache or by name."), *ActorClass->GetName(), *PropertyName);
+        {Ref_AssignTo} = ({Declare_PropertyCPPType}*)((uint8*){Ref_ContainerAddr} + {Num_PropMemOffset});
+    }
 }
 )EOF";
-
-static const TCHAR* PropDecorator_AssignPropPtrForGlobalStructTemp =
-LR"EOF({Ref_AssignTo} = ({Declare_PropertyCPPType}*)((uint8*){Ref_ContainerAddr} + {Num_PropMemOffset}))EOF";
 
 const static TCHAR* PropDecorator_SetDeltaStateTemplate =
 	LR"EOF(
@@ -231,8 +240,7 @@ public:
 
 	virtual FString GetCode_AssignPropPointer(const FString& Container, const FString& AssignTo);
 	virtual FString GetCode_AssignPropPointer(const FString& Container, const FString& AssignTo, int32 MemOffset);
-    virtual FString GetCode_AssignPropPointerForGlobalStruct(const FString& Container, const FString& AssignTo);
-    virtual FString GetCode_AssignPropPointerForGlobalStruct(const FString& Container, const FString& AssignTo, int32 MemOffset);
+    static TMap<FString, int32> PropPointerMemOffsetCache;
 
 	/**
 	 * Code that get field value from protobuf message

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator/StructPropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator/StructPropertyDecorator.h
@@ -56,7 +56,12 @@ struct {Declare_PropCompilableStructName}
 };
 )EOF";
 
-const static TCHAR* StructPropDeco_AssignPropPtrTemp =
+const static TCHAR* StructPropDeco_AssignPropPtrStatic =
+	LR"EOF(
+void* PropertyAddr = (uint8*){Ref_ContainerAddr} + {Num_PropMemOffset};
+{Ref_AssignTo} = {Declare_PropPtrGroupStructName}(PropertyAddr))EOF";
+
+const static TCHAR* StructPropDeco_AssignPropPtrDynamic =
     LR"EOF(
 FString PropertyName = TEXT("{Declare_PropertyName}");
 void* PropertyAddr = (uint8*){Ref_ContainerAddr};
@@ -121,8 +126,9 @@ public:
 	virtual FString GetPropertyType() override;
 	
 	virtual FString GetDeclaration_PropertyPtr() override;
-	
-	virtual FString GetCode_AssignPropPointer(const FString& Container, const FString& AssignTo, int32 MemOffset) override;
+
+	virtual FString GetCode_AssignPropPointerStatic(const FString& Container, const FString& AssignTo) override;
+	virtual FString GetCode_AssignPropPointerDynamic(const FString& Container, const FString& AssignTo) override;
 	
 	virtual TArray<FString> GetAdditionalIncludes() override;
 	
@@ -141,7 +147,7 @@ public:
 
 	virtual FString GetCode_SetPropertyValueArrayInner(const FString& ArrayPropertyName, const FString& TargetInstance, const FString& NewStateName) override;
 
-	FString GetDeclaration_PropPtrGroupStruct();
+	virtual FString GetDeclaration_PropPtrGroupStruct();
 
 	FString GetDeclaration_PropPtrGroupStructName();
 

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator/StructPropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator/StructPropertyDecorator.h
@@ -70,6 +70,11 @@ else {
 }
 )EOF";
 
+const static TCHAR* StructPropDeco_AssignPropPtrForGlobalStructTemp =
+    LR"EOF(
+void* PropertyAddr = (uint8*){Ref_ContainerAddr} + {Num_PropMemOffset};
+{Ref_AssignTo} = {Declare_PropPtrGroupStructName}(PropertyAddr))EOF";
+
 const static TCHAR* StructPropDeco_SetDeltaStateArrayInnerTemp =
 	LR"EOF(
 {

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator/StructPropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator/StructPropertyDecorator.h
@@ -60,9 +60,10 @@ const static TCHAR* StructPropDeco_AssignPropPtrTemp =
     LR"EOF(
 FString PropertyName = TEXT("{Declare_PropertyName}");
 void* PropertyAddr = (uint8*){Ref_ContainerAddr};
-if (StructPropPointerMemOffsetCache.Contains(PropertyName))
+int32* OffsetPtr = PropPointerMemOffsetCache.Find(PropertyName);
+if (OffsetPtr != nullptr)
 {    
-    {Ref_AssignTo} = ({Declare_PropPtrGroupStructName})(PropertyAddr + StructPropPointerMemOffsetCache[PropertyName]);
+    {Ref_AssignTo} = ({Declare_PropPtrGroupStructName})(PropertyAddr + *OffsetPtr);
 }
 else
 {
@@ -70,7 +71,7 @@ else
     if (Property)
     {
         int32 Offset = Property->GetOffset_ForInternal();
-        StructPropPointerMemOffsetCache.Emplace(PropertyName, Offset);
+        PropPointerMemOffsetCache.Emplace(PropertyName, Offset);
         {Ref_AssignTo} = ({Declare_PropPtrGroupStructName})(PropertyAddr + Offset);
     }
     else
@@ -122,7 +123,6 @@ public:
 	virtual FString GetDeclaration_PropertyPtr() override;
 	
 	virtual FString GetCode_AssignPropPointer(const FString& Container, const FString& AssignTo, int32 MemOffset) override;
-    static TMap<FString, int32> StructPropPointerMemOffsetCache;
 	
 	virtual TArray<FString> GetAdditionalIncludes() override;
 	

--- a/Source/ReplicatorGenerator/Public/PropertyDecorator/StructPropertyDecorator.h
+++ b/Source/ReplicatorGenerator/Public/PropertyDecorator/StructPropertyDecorator.h
@@ -57,9 +57,18 @@ struct {Declare_PropCompilableStructName}
 )EOF";
 
 const static TCHAR* StructPropDeco_AssignPropPtrTemp =
-	LR"EOF(
-void* PropertyAddr = (uint8*){Ref_ContainerAddr} + {Num_PropMemOffset};
-{Ref_AssignTo} = {Declare_PropPtrGroupStructName}(PropertyAddr))EOF";
+    LR"EOF(
+FString PropertyName = TEXT("{Declare_PropertyName}");
+FProperty* Property = ActorClass->FindPropertyByName(FName(*PropertyName));
+if (Property) {
+	void* PropertyAddr = (uint8*){Ref_ContainerAddr} + Property->GetOffset_ForInternal();
+	{Ref_AssignTo} = {Declare_PropPtrGroupStructName}(PropertyAddr);
+}
+else {
+	void* PropertyAddr = (uint8*){Ref_ContainerAddr} + {Num_PropMemOffset};
+	{Ref_AssignTo} = {Declare_PropPtrGroupStructName}(PropertyAddr);
+}
+)EOF";
 
 const static TCHAR* StructPropDeco_SetDeltaStateArrayInnerTemp =
 	LR"EOF(
@@ -102,6 +111,7 @@ public:
 	virtual FString GetDeclaration_PropertyPtr() override;
 	
 	virtual FString GetCode_AssignPropPointer(const FString& Container, const FString& AssignTo, int32 MemOffset) override;
+    virtual FString GetCode_AssignPropPointerForGlobalStruct(const FString& Container, const FString& AssignTo, int32 MemOffset) override;
 	
 	virtual TArray<FString> GetAdditionalIncludes() override;
 	

--- a/Source/ReplicatorGenerator/Public/ReplicatorTemplate/BlueprintReplicatorTemplate.h
+++ b/Source/ReplicatorGenerator/Public/ReplicatorTemplate/BlueprintReplicatorTemplate.h
@@ -28,6 +28,7 @@ public:
 
 protected:
   TWeakObjectPtr<{Declare_TargetBaseClassName}> {Ref_TargetInstanceRef};
+  static TMap<FString, int32> PropPointerMemOffsetCache; 
 
   // [Server+Client] The accumulated channel data of the target object
   {Declare_ProtoNamespace}::{Declare_ProtoStateMsgName}* FullState;

--- a/Source/ReplicatorGenerator/Public/ReplicatorTemplate/BlueprintReplicatorTemplate.h
+++ b/Source/ReplicatorGenerator/Public/ReplicatorTemplate/BlueprintReplicatorTemplate.h
@@ -54,7 +54,7 @@ static const TCHAR* CodeGen_BP_ConstructorImplTemplate =
   FullState = new {Declare_ProtoNamespace}::{Declare_ProtoStateMsgName};
   DeltaState = new {Declare_ProtoNamespace}::{Declare_ProtoStateMsgName};
   
-  UClass* ActorClass = {Declare_TargetClassName}::StaticClass();
+  UClass* ActorClass = GetTargetClass();
   if (!ActorClass) {
     return;
   }

--- a/Source/ReplicatorGenerator/Public/ReplicatorTemplate/BlueprintReplicatorTemplate.h
+++ b/Source/ReplicatorGenerator/Public/ReplicatorTemplate/BlueprintReplicatorTemplate.h
@@ -52,6 +52,11 @@ static const TCHAR* CodeGen_BP_ConstructorImplTemplate =
 
   FullState = new {Declare_ProtoNamespace}::{Declare_ProtoStateMsgName};
   DeltaState = new {Declare_ProtoNamespace}::{Declare_ProtoStateMsgName};
+  
+  UClass* ActorClass = {Declare_TargetClassName}::StaticClass();
+  if (!ActorClass) {
+    return;
+  }
 
 {Code_AssignPropertyPointers}
 }

--- a/Source/ReplicatorGenerator/Public/ReplicatorTemplate/CppReplicatorTemplate.h
+++ b/Source/ReplicatorGenerator/Public/ReplicatorTemplate/CppReplicatorTemplate.h
@@ -30,6 +30,7 @@ public:
 
 protected:
   TWeakObjectPtr<{Declare_TargetClassName}> {Ref_TargetInstanceRef};
+  static TMap<FString, int32> PropPointerMemOffsetCache;  
 
   // [Server+Client] The accumulated channel data of the target object
   {Declare_ProtoNamespace}::{Declare_ProtoStateMsgName}* FullState;

--- a/Source/ReplicatorGenerator/Public/ReplicatorTemplate/CppReplicatorTemplate.h
+++ b/Source/ReplicatorGenerator/Public/ReplicatorTemplate/CppReplicatorTemplate.h
@@ -60,6 +60,11 @@ static const TCHAR* CodeGen_CPP_ConstructorImplTemplate =
   FullState = new {Declare_ProtoNamespace}::{Declare_ProtoStateMsgName};
   DeltaState = new {Declare_ProtoNamespace}::{Declare_ProtoStateMsgName};
 
+  UClass* ActorClass = {Declare_TargetClassName}::StaticClass();
+  if (!ActorClass) {
+    return;
+  }
+
 {Code_AssignPropertyPointers}
 }
 )EOF";


### PR DESCRIPTION
Fixed the issues introduced in PR #69:
- Structs use the static memory offset for property pointers;
- Only the actor replicated property use the dynamic memory offset;
- `PropPointerMemOffsetCache` was not defined in generated cpp;